### PR TITLE
Update dora-the-explorer repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -226,7 +226,7 @@
 #  dora-the-explorer  #
 #############
 - source:
-    repository: pk910/light-beaconchain-explorer
+    repository: pk910/dora-the-explorer
     ref: master
   target:
     tag: master


### PR DESCRIPTION
Renamed the repository to `dora-the-explorer`.
This PR updates the reference to the repository in `config.yaml`.