### PR TITLE
feat(lighthouse): set default feature flags and remove specific min b…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,23 +101,6 @@
     tag: unstable
     repository: ethpandaops/lighthouse
     dockerfile: ./lighthouse/Dockerfile
-  # Minimal builds
-- source:
-    repository: sigp/lighthouse
-    ref: stable
-  build_args: FEATURES=spec-minimal  
-  target:
-    tag: stable-minimal
-    repository: ethpandaops/lighthouse
-    dockerfile: ./lighthouse/Dockerfile
-- source:
-    repository: sigp/lighthouse
-    ref: unstable
-  build_args: FEATURES=spec-minimal  
-  target:
-    tag: unstable-minimal
-    repository: ethpandaops/lighthouse
-    dockerfile: ./lighthouse/Dockerfile
   # Xatu Sentry builds
 - source:
     repository: sigp/lighthouse

--- a/lighthouse/Dockerfile
+++ b/lighthouse/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.76-bullseye AS builder
 RUN apt-get clean && apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler
 COPY . lighthouse
-ARG FEATURES
+ARG FEATURES=gnosis,spec-minimal,slasher-lmdb,jemalloc
 ARG PROFILE=release
 ARG CARGO_USE_GIT_CLI=true
 ENV FEATURES $FEATURES


### PR DESCRIPTION
```bash
docker run --rm 192.168.45.152:80/dh/ethpandaops/lighthouse:unstable-f37ffe4 lighthouse --version
Lighthouse v5.1.3-f37ffe4
BLS library: blst
SHA256 hardware acceleration: false
Allocator: jemalloc
Profile: release
Specs: mainnet (true), minimal (true), gnosis (true)
```
new defaults here
https://github.com/sigp/lighthouse/blob/unstable/.github/workflows/docker.yml#L78