### PR TITLE
Prysm: disable bzlmod

### DIFF
--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -12,7 +12,7 @@ else
   sudo apt install -y ca-certificates python3 golang-go
   go install github.com/bazelbuild/bazelisk@latest
 fi
-$HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0
+$HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false
 # move to base dir to avoid any dockerignore/stat issues
 mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh

--- a/prysm/build_beacon_minimal.sh
+++ b/prysm/build_beacon_minimal.sh
@@ -12,7 +12,7 @@ else
   sudo apt install -y ca-certificates python3 golang-go
   go install github.com/bazelbuild/bazelisk@latest
 fi
-$HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0
+$HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false
 # move to base dir to avoid any dockerignore/stat issues
 mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh

--- a/prysm/build_validator.sh
+++ b/prysm/build_validator.sh
@@ -12,7 +12,7 @@ else
   sudo apt install -y ca-certificates python3 golang-go
   go install github.com/bazelbuild/bazelisk@latest
 fi
-$HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0
+$HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false
 # move to base dir to avoid any dockerignore/stat issues
 mv bazel-bin/cmd/validator/validator_/validator _validator
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh

--- a/prysm/build_validator_minimal.sh
+++ b/prysm/build_validator_minimal.sh
@@ -12,7 +12,7 @@ else
   sudo apt install -y ca-certificates python3 golang-go
   go install github.com/bazelbuild/bazelisk@latest
 fi
-$HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0
+$HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false
 # move to base dir to avoid any dockerignore/stat issues
 mv bazel-bin/cmd/validator/validator_/validator _validator
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh


### PR DESCRIPTION
This PR disables bzlmod which seems to be rate limiting or banning the builder.

```
Error in download: java.io.IOException: Error downloading [https://bcr.bazel.build/modules/rules_cc/0.0.9/patches/module_dot_bazel_version.patch] to /data/gh-home/.cache/bazel/_bazel_root/e06669d813ee8962af5ff3fbbdf856de/external/rules_cc~/.tmp_remote_patches/module_dot_bazel_version.patch: GET returned 403 Forbidden
```

A long term solution is to cache the bazel build directories or use a [remote cache](https://bazel.build/remote/caching) with [`--experimental-remote-downloader=grpc://$REMOTE_CACHE`](https://bazel.build/reference/command-line-reference#flag--experimental_remote_downloader) and [`--remote_cache=grpc://$REMOTE_CACHE`](https://bazel.build/reference/command-line-reference#flag--remote_cache). This would fetch the remote dependencies from the remote cache box as a proxy and cache any interim build steps. You won't bomb / get banned from dependency providers and build times should increase significantly when builds haven't  changed much.

Edit: I meant the [`--experimental_remote_asset_api` flag](https://github.com/buchgr/bazel-remote/?tab=readme-ov-file#experimental-remote-asset-api-support)