### PR TITLE
refactor(prysm): build cfg

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -136,6 +136,7 @@ runs:
       push: true
       platforms: ${{ inputs.platform }}
       build-args: ${{ inputs.build_args }}
+      build_method: ${{ inputs.build_method }}
       labels: |
         ethpandaops.io.repo=${{ inputs.source_repository }}
         ethpandaops.io.commitRef=${{ inputs.source_ref }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -36,6 +36,11 @@ inputs:
     description: The platform to build for
     type: string
     required: true
+  build_method:
+    description: Build method to use (go or bazel)
+    type: string
+    default: bazel
+    required: false
   # Secrets
   DOCKER_USERNAME:
     required: true
@@ -96,6 +101,7 @@ runs:
       target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
       GOPROXY: ${{ inputs.GOPROXY }}
+      build_method: ${{ inputs.build_method }}
     run: |
       ${{ inputs.build_script }}
   - name: Image digest & tags (build script)

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -17,6 +17,14 @@ on:
         description: Override target docker tag (defaults to the above source ref if left blank)
         type: string
         required: false
+      build_method:
+        description: Build method to use (go or bazel)
+        type: choice
+        options:
+          - bazel
+          - go
+        default: bazel
+        required: true
 
 jobs:
   prepare:
@@ -58,7 +66,7 @@ jobs:
           target_repository: ethpandaops/prysm-beacon-chain
           target_dockerfile: ./prysm/Dockerfile.beacon
           platform: ${{ matrix.platform }}
-          prysm_build_with: go
+          build_method: ${{ inputs.build_method }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -86,6 +94,7 @@ jobs:
           target_repository: ethpandaops/prysm-beacon-chain
           target_dockerfile: ./prysm/Dockerfile.beacon
           platform: ${{ matrix.platform }}
+          build_method: ${{ inputs.build_method }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -113,6 +122,7 @@ jobs:
           target_repository: ethpandaops/prysm-validator
           target_dockerfile: ./prysm/Dockerfile.validator
           platform: ${{ matrix.platform }}
+          build_method: ${{ inputs.build_method }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -140,6 +150,7 @@ jobs:
           target_repository: ethpandaops/prysm-validator
           target_dockerfile: ./prysm/Dockerfile.validator
           platform: ${{ matrix.platform }}
+          build_method: ${{ inputs.build_method }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -23,7 +23,7 @@ on:
         options:
           - bazel
           - go
-        default: go
+        default: bazel
         required: true
 
 jobs:

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -58,6 +58,7 @@ jobs:
           target_repository: ethpandaops/prysm-beacon-chain
           target_dockerfile: ./prysm/Dockerfile.beacon
           platform: ${{ matrix.platform }}
+          prysm_build_with: go
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -23,7 +23,7 @@ on:
         options:
           - bazel
           - go
-        default: bazel
+        default: go
         required: true
 
 jobs:

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -13,9 +13,9 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-prysm_build_with=${prysm_build_with:-bazel}  # Default to bazel if not set
+build_method=${build_method:-bazel}  # Default to bazel if not set
 
-case ${prysm_build_with} in
+case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
@@ -27,7 +27,7 @@ case ${prysm_build_with} in
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain
     ;;
   *)
-    echo "Invalid BUILD_WITH value: ${prysm_build_with}. Must be 'go' or 'bazel'"
+    echo "Invalid build_method value: ${build_method}. Must be 'go' or 'bazel'"
     exit 1
     ;;
 esac

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -19,9 +19,22 @@ case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
+    
+    # Define ldflags for version information
+    ldflags=$(cat <<-END
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitCommit=$(git rev-parse HEAD)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitTag=$(git describe --tags 2>/dev/null || echo Unknown)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDate=$(date -u +%Y-%m-%d\ %H:%M:%S%:z)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDateUnix=$(date +%s)'
+END
+    )
+    
     # Build with blst_enabled and blst_portable to support both amd64 and arm64. The BLST library (used for
     # cryptographic operations) needs specific CPU features.
-    CGO_ENABLED=1 go build -tags=blst_enabled,blst_portable -o _beacon-chain ./cmd/beacon-chain
+    CGO_ENABLED=1 go build \
+      -tags=blst_enabled,blst_portable \
+      -ldflags "${ldflags}" \
+      -o _beacon-chain ./cmd/beacon-chain
     ;;
   "bazel")
     echo "Building with Bazel..."

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -13,27 +13,24 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_with_go() {
-  echo "Building with Go..."
-  go mod tidy
-  CGO_ENABLED=1 go build -o _beacon-chain ./cmd/beacon-chain
-}
+prysm_build_with=${prysm_build_with:-bazel}  # Default to bazel if not set
 
-build_with_bazel() {
-  echo "Building with Bazel..."
-  $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
-  if [ $? -eq 0 ]; then
-    # move to base dir to avoid any dockerignore/stat issues
+case ${prysm_build_with} in
+  "go")
+    echo "Building with Go..."
+    go mod tidy
+    CGO_ENABLED=1 go build -o _beacon-chain ./cmd/beacon-chain
+    ;;
+  "bazel")
+    echo "Building with Bazel..."
+    $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain
-    return 0
-  else
-    echo "Bazel build failed, falling back to go build..."
-    return 1
-  fi
-}
-
-# Try Bazel first, fall back to Go if it fails.
-build_with_bazel || build_with_go
+    ;;
+  *)
+    echo "Invalid BUILD_WITH value: ${prysm_build_with}. Must be 'go' or 'bazel'"
+    exit 1
+    ;;
+esac
 
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh
 

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -13,7 +13,7 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_method=${build_method:-bazel}  # Default to bazel if not set
+build_method=${build_method:-go}  # Default to go if not set
 
 case ${build_method} in
   "go")

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -19,7 +19,9 @@ case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
-    CGO_ENABLED=1 go build -o _beacon-chain ./cmd/beacon-chain
+    # Build with blst_enabled and blst_portable to support both amd64 and arm64. The BLST library (used for
+    # cryptographic operations) needs specific CPU features.
+    CGO_ENABLED=1 go build -tags=blst_enabled,blst_portable -o _beacon-chain ./cmd/beacon-chain
     ;;
   "bazel")
     echo "Building with Bazel..."

--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -13,7 +13,7 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_method=${build_method:-go}  # Default to go if not set
+build_method=${build_method:-bazel}  # Default to bazel if not set
 
 case ${build_method} in
   "go")

--- a/prysm/build_beacon_minimal.sh
+++ b/prysm/build_beacon_minimal.sh
@@ -13,27 +13,24 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_with_go() {
-  echo "Building with Go..."
-  go mod tidy
-  CGO_ENABLED=1 go build -tags="minimal" -o _beacon-chain ./cmd/beacon-chain
-}
+build_method=${build_method:-bazel}  # Default to bazel if not set
 
-build_with_bazel() {
-  echo "Building with Bazel..."
-  $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
-  if [ $? -eq 0 ]; then
-    # move to base dir to avoid any dockerignore/stat issues
+case ${build_method} in
+  "go")
+    echo "Building with Go..."
+    go mod tidy
+    CGO_ENABLED=1 go build -tags="minimal,blst_enabled,blst_portable" -o _beacon-chain ./cmd/beacon-chain
+    ;;
+  "bazel")
+    echo "Building with Bazel..."
+    $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain
-    return 0
-  else
-    echo "Bazel build failed, falling back to go build..."
-    return 1
-  fi
-}
-
-# Try Bazel first, fall back to Go if it fails.
-build_with_bazel || build_with_go
+    ;;
+  *)
+    echo "Invalid build_method value: ${build_method}. Must be 'go' or 'bazel'"
+    exit 1
+    ;;
+esac
 
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh
 

--- a/prysm/build_beacon_minimal.sh
+++ b/prysm/build_beacon_minimal.sh
@@ -19,7 +19,22 @@ case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
-    CGO_ENABLED=1 go build -tags="minimal,blst_enabled,blst_portable" -o _beacon-chain ./cmd/beacon-chain
+    
+    # Define ldflags for version information
+    ldflags=$(cat <<-END
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitCommit=$(git rev-parse HEAD)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitTag=$(git describe --tags 2>/dev/null || echo Unknown)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDate=$(date -u +%Y-%m-%d\ %H:%M:%S%:z)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDateUnix=$(date +%s)'
+END
+    )
+    
+    # Build with blst_enabled and blst_portable to support both amd64 and arm64. The BLST library (used for
+    # cryptographic operations) needs specific CPU features.
+    CGO_ENABLED=1 go build \
+      -tags=blst_enabled,blst_portable \
+      -ldflags "${ldflags}" \
+      -o _beacon-chain ./cmd/beacon-chain
     ;;
   "bazel")
     echo "Building with Bazel..."

--- a/prysm/build_validator.sh
+++ b/prysm/build_validator.sh
@@ -13,27 +13,24 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_with_go() {
-  echo "Building with Go..."
-  go mod tidy
-  CGO_ENABLED=1 go build -o _validator ./cmd/validator
-}
+build_method=${build_method:-bazel}  # Default to bazel if not set
 
-build_with_bazel() {
-  echo "Building with Bazel..."
-  $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
-  if [ $? -eq 0 ]; then
-    # move to base dir to avoid any dockerignore/stat issues
+case ${build_method} in
+  "go")
+    echo "Building with Go..."
+    go mod tidy
+    CGO_ENABLED=1 go build -tags=blst_enabled,blst_portable -o _validator ./cmd/validator
+    ;;
+  "bazel")
+    echo "Building with Bazel..."
+    $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
     mv bazel-bin/cmd/validator/validator_/validator _validator
-    return 0
-  else
-    echo "Bazel build failed, falling back to go build..."
-    return 1
-  fi
-}
-
-# Try Bazel first, fall back to Go if it fails.
-build_with_bazel || build_with_go
+    ;;
+  *)
+    echo "Invalid build_method value: ${build_method}. Must be 'go' or 'bazel'"
+    exit 1
+    ;;
+esac
 
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh
 

--- a/prysm/build_validator.sh
+++ b/prysm/build_validator.sh
@@ -19,7 +19,22 @@ case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
-    CGO_ENABLED=1 go build -tags=blst_enabled,blst_portable -o _validator ./cmd/validator
+    
+    # Define ldflags for version information
+    ldflags=$(cat <<-END
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitCommit=$(git rev-parse HEAD)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitTag=$(git describe --tags 2>/dev/null || echo Unknown)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDate=$(date -u +%Y-%m-%d\ %H:%M:%S%:z)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDateUnix=$(date +%s)'
+END
+    )
+    
+    # Build with blst_enabled and blst_portable to support both amd64 and arm64. The BLST library (used for
+    # cryptographic operations) needs specific CPU features.
+    CGO_ENABLED=1 go build \
+      -tags=blst_enabled,blst_portable \
+      -ldflags "${ldflags}" \
+      -o _validator ./cmd/validator
     ;;
   "bazel")
     echo "Building with Bazel..."

--- a/prysm/build_validator_minimal.sh
+++ b/prysm/build_validator_minimal.sh
@@ -19,7 +19,22 @@ case ${build_method} in
   "go")
     echo "Building with Go..."
     go mod tidy
-    CGO_ENABLED=1 go build -tags="minimal,blst_enabled,blst_portable" -o _validator ./cmd/validator
+    
+    # Define ldflags for version information
+    ldflags=$(cat <<-END
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitCommit=$(git rev-parse HEAD)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.gitTag=$(git describe --tags 2>/dev/null || echo Unknown)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDate=$(date -u +%Y-%m-%d\ %H:%M:%S%:z)' \
+        -X 'github.com/prysmaticlabs/prysm/v5/runtime/version.buildDateUnix=$(date +%s)'
+END
+    )
+    
+    # Build with blst_enabled and blst_portable to support both amd64 and arm64. The BLST library (used for
+    # cryptographic operations) needs specific CPU features.
+    CGO_ENABLED=1 go build \
+      -tags=blst_enabled,blst_portable \
+      -ldflags "${ldflags}" \
+      -o _validator ./cmd/validator
     ;;
   "bazel")
     echo "Building with Bazel..."

--- a/prysm/build_validator_minimal.sh
+++ b/prysm/build_validator_minimal.sh
@@ -13,27 +13,24 @@ else
   go install github.com/bazelbuild/bazelisk@latest
 fi
 
-build_with_go() {
-  echo "Building with Go..."
-  go mod tidy
-  CGO_ENABLED=1 go build -tags="minimal" -o _validator ./cmd/validator
-}
+build_method=${build_method:-bazel}  # Default to bazel if not set
 
-build_with_bazel() {
-  echo "Building with Bazel..."
-  $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
-  if [ $? -eq 0 ]; then
-    # move to base dir to avoid any dockerignore/stat issues
+case ${build_method} in
+  "go")
+    echo "Building with Go..."
+    go mod tidy
+    CGO_ENABLED=1 go build -tags="minimal,blst_enabled,blst_portable" -o _validator ./cmd/validator
+    ;;
+  "bazel")
+    echo "Building with Bazel..."
+    $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443
     mv bazel-bin/cmd/validator/validator_/validator _validator
-    return 0
-  else
-    echo "Bazel build failed, falling back to go build..."
-    return 1
-  fi
-}
-
-# Try Bazel first, fall back to Go if it fails.
-build_with_bazel || build_with_go
+    ;;
+  *)
+    echo "Invalid build_method value: ${build_method}. Must be 'go' or 'bazel'"
+    exit 1
+    ;;
+esac
 
 cp ${SCRIPT_DIR}/entrypoint.sh entrypoint.sh
 


### PR DESCRIPTION
- Expose build_method allowing us to select either `bazel` or `go` build method.
- Tweaks to `go` build method to ensure ldflags are passed through, as they are with `bazel` build versions, eg: 

> `Prysm/v5.1.3-rc.0-42-g30a136f1f/30a136f1fbd3f62b02369be9878decbfdeb3b648. Built at: 2024-12-06 05:57:40+00:00`