### PR TITLE
feat: expose full commit hash to build scripts

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -62,12 +62,18 @@ runs:
       repository: ${{ inputs.source_repository }}
       path: source
       ref: ${{ inputs.source_ref }}
-  - name: get git commit hash
+  - name: get short git commit hash
     id: git_commit_hash
     shell: bash
     run: |
       cd source
       echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
+  - name: get full git commit hash
+    id: git_commit_hash_full
+    shell: bash
+    run: |
+      cd source
+      echo "git_commit_hash=$(echo $(git log --pretty=format:'%H' -n 1))" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context
@@ -100,6 +106,7 @@ runs:
       target_repository: ${{ inputs.target_repository }}
       target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+      source_git_commit_hash_full: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
       GOPROXY: ${{ inputs.GOPROXY }}
       build_method: ${{ inputs.build_method }}
     run: |

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -73,7 +73,7 @@ runs:
     shell: bash
     run: |
       cd source
-      echo "git_commit_hash=$(echo $(git log --pretty=format:'%H' -n 1))" >> $GITHUB_OUTPUT
+      echo "git_commit_hash_full=$(echo $(git log --pretty=format:'%H' -n 1))" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The following environment variables are available to the `build_script`;
 - `target_tag` - tag to add to the docker image tag
 - `target_repository` - dockerhub target to deploy the built image
 - `target_dockerfile` - optional docker file to use, defaults to the source repository's Dockerfile
-- `source_git_commit_hash` - the source repository's commit hash
+- `source_git_commit_hash` - the source repository's short commit hash
+- `source_git_commit_hash_full` - the source repository's full commit hash
 
 Example `build_script` file;
 ```bash

--- a/lodestar/build.sh
+++ b/lodestar/build.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}/../source
 
-docker build --build-arg "COMMIT=${source_git_commit_hash}" -t "${target_repository}:${target_tag}" .
+docker build --build-arg "COMMIT=${source_git_commit_hash_full}" -t "${target_repository}:${target_tag}" .
 docker push "${target_repository}:${target_tag}"
 docker tag "${target_repository}:${target_tag}" "${target_repository}:${target_tag}-${source_git_commit_hash}"
 docker push "${target_repository}:${target_tag}-${source_git_commit_hash}"


### PR DESCRIPTION
Closes #212

before;
```bash
docker run -it ethpandaops/lodestar:unstable-d55bb2d beacon
info: Lodestar network=mainnet, version=v1.23.1/d55bb2d, commit=d55bb2d
```

after
```
docker run -it ethpandaops/lodestar:unstable-test-e353f67 beacon
info: Lodestar network=mainnet, version=v1.23.1/e353f67, commit=e353f67426581e622c6df83c30992b4a28dcb617
```