### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -55,9 +55,9 @@ runs:
   using: composite
   steps:
   - name: Checkout this repo
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   - name: Check out source repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     with:
       repository: ${{ inputs.source_repository }}
       path: source
@@ -80,7 +80,7 @@ runs:
     run: |
       docker context use builders || docker context create builders 
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     with:
       endpoint: builders
   - name: Unlock MacOS keychain for Docker Hub login
@@ -89,7 +89,7 @@ runs:
     run: |
       security -v unlock-keychain -p ${{ inputs.MACOS_PASSWORD }} ~/Library/Keychains/login.keychain-db
   - name: Login to Docker Hub
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}
@@ -138,7 +138,7 @@ runs:
   - name: Docker build & push
     if: ${{ inputs.build_script == '' }}
     id: docker_build
-    uses: docker/build-push-action@v5
+    uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
     with:
       context: ./source
       file: ${{ inputs.target_dockerfile }}

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -11,23 +11,23 @@ runs:
   using: composite
   steps:
   - name: Checkout this repo
-    uses: actions/checkout@v4
-  - uses: actions/setup-java@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+  - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
     if: contains(inputs.repository, 'teku')
     with:
       distribution: 'temurin'
       java-version: '21'
-  - uses: actions/setup-java@v4
+  - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
     if: contains(inputs.repository, 'besu')
     with:
       distribution: 'temurin'
       java-version: '21'
-  - uses: actions/setup-node@v4
+  - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
     if: contains(inputs.repository, 'lodestar') || contains(inputs.repository, 'ethereumjs')
     with:
       node-version: 20
       check-latest: true
-  - uses: actions/setup-go@v4
+  - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
     if: contains(inputs.repository, 'prysm')
     with:
       go-version: '1.22.0'

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -40,9 +40,9 @@ runs:
   using: composite
   steps:
   - name: Checkout this repo
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   - name: Check out source repository
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     with:
       repository: ${{ inputs.source_repository }}
       path: source
@@ -92,11 +92,11 @@ runs:
     run: |
       docker context create builders
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     with:
       endpoint: builders
   - name: Login to Docker Hub
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}
@@ -108,7 +108,7 @@ runs:
 
   - name: Login to harbor registry
     if: ${{ inputs.harbor_registry != '' }}
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
     with:
       registry: ${{ inputs.harbor_registry }}
       username: ${{ inputs.HARBOR_USERNAME }}

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -12,8 +12,8 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    - uses: mikefarah/yq@v4.35.1
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: mikefarah/yq@6609ed76ecb69f9d8254345292d90ea72f641715 # v4.35.1
     - name: Generate platform and runner matrix from config files
       id: setup_platforms
       shell: bash

--- a/.github/workflows/build-push-armiarma.yml
+++ b/.github/workflows/build-push-armiarma.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -70,7 +70,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -70,7 +70,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -68,7 +68,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -92,7 +92,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -66,7 +66,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -90,7 +90,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -68,7 +68,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -92,7 +92,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -70,7 +70,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-genesis-generator.yml
+++ b/.github/workflows/build-push-genesis-generator.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -70,7 +70,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -69,7 +69,7 @@ jobs:
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         id: manifest
         with:
@@ -94,7 +94,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: true
       - name: Prepare Matrix
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -69,7 +69,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -93,7 +93,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -72,7 +72,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -99,7 +99,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -116,7 +116,7 @@ jobs:
       - deploy-minimal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -139,7 +139,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -30,7 +30,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -74,7 +74,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -98,7 +98,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -68,7 +68,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -93,7 +93,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }} 

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }} 

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -30,7 +30,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -73,7 +73,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -97,7 +97,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -71,7 +71,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -97,7 +97,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/deploy
         with:
           source_repository: ${{ inputs.repository }}
@@ -120,7 +120,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/deploy
         with:
           source_repository: ${{ inputs.repository }}
@@ -140,7 +140,7 @@ jobs:
       - deploy-beacon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -160,7 +160,7 @@ jobs:
       - deploy-beacon-minimal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -180,7 +180,7 @@ jobs:
       - deploy-validator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -200,7 +200,7 @@ jobs:
       - deploy-validator-minimal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -230,7 +230,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -33,7 +33,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -53,7 +53,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -109,7 +109,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -137,7 +137,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -162,7 +162,7 @@ jobs:
       - deploy-beacon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -182,7 +182,7 @@ jobs:
       - deploy-beacon-minimal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -202,7 +202,7 @@ jobs:
       - deploy-validator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -222,7 +222,7 @@ jobs:
       - deploy-validator-minimal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -252,7 +252,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -30,7 +30,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -73,7 +73,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -97,7 +97,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }} 

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: "${{ inputs.repository }}"
@@ -68,7 +68,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -92,7 +92,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -25,7 +25,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
@@ -67,7 +67,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           source_repository: ${{ inputs.repository }}
@@ -91,7 +91,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         config: ${{fromJson(inputs.platforms)}}
     runs-on: ${{ matrix.config.runner }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - uses: ./.github/actions/install-deps
       with:
         repository: ${{ inputs.source_repository }}
@@ -93,7 +93,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - uses: ./.github/actions/manifest
       with:
         platforms: ${{ inputs.platforms }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,10 +15,10 @@ jobs:
     outputs:
       configs: ${{ steps.repo_check.outputs.configs }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: mikefarah/yq@v4.35.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: mikefarah/yq@6609ed76ecb69f9d8254345292d90ea72f641715 # v4.35.1
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -246,7 +246,7 @@ jobs:
     if: cancelled() || failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: schema validate
-        uses: nrkno/yaml-schema-validator-github-action@v4
+        uses: nrkno/yaml-schema-validator-github-action@4280780c703671c96fcdf493b2e64b16e25c4941 # v4
         with:
           schema: schema.yaml
           target: config.yaml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: mikefarah/yq@v4.30.8
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: mikefarah/yq@dd6cf3df146f3e2c0f8c765a6ef9e35780ad8cc1 # v4.30.8
       - name: duplicate repository tag check
         run: |
           OUTPUT=$(yq 'group_by(.target.repository + ":" + .target.tag) | map(select(length>1))' config.yaml)
@@ -39,7 +39,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           github-token: ${{ secrets.github_token }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.