### PR TITLE
fix: using the correct commit hash for manifest

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -55,6 +55,9 @@ outputs:
   git_commit_hash:
     description: The git commit hash that was used to build the image
     value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+  git_commit_hash_full:
+    description: The full git commit hash that was used to build the image
+    value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
 
 runs:
   using: composite
@@ -73,6 +76,12 @@ runs:
     run: |
       cd source
       echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
+  - name: get full git commit hash
+    id: git_commit_hash_full
+    shell: bash
+    run: |
+      cd source
+      echo "git_commit_hash_full=$(git log --pretty=format:'%H' -n 1)" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context
@@ -105,6 +114,7 @@ runs:
       target_repository: ${{ inputs.target_repository }}
       target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+      source_git_commit_hash_full: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
       GOPROXY: ${{ inputs.GOPROXY }}
       build_method: ${{ inputs.build_method }}
     run: |

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -51,14 +51,6 @@ inputs:
   GOPROXY:
     required: false
 
-outputs:
-  git_commit_hash:
-    description: The git commit hash that was used to build the image
-    value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
-  git_commit_hash_full:
-    description: The full git commit hash that was used to build the image
-    value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -75,13 +75,13 @@ runs:
     shell: bash
     run: |
       cd source
-      echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
+      echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
   - name: get full git commit hash
     id: git_commit_hash_full
     shell: bash
     run: |
       cd source
-      echo "git_commit_hash_full=$(git log --pretty=format:'%H' -n 1)" >> $GITHUB_OUTPUT
+      echo "git_commit_hash_full=$(echo $(git log --pretty=format:'%H' -n 1))" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -105,7 +105,6 @@ runs:
       target_repository: ${{ inputs.target_repository }}
       target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
-      source_git_commit_hash_full: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
       GOPROXY: ${{ inputs.GOPROXY }}
       build_method: ${{ inputs.build_method }}
     run: |

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -51,6 +51,11 @@ inputs:
   GOPROXY:
     required: false
 
+outputs:
+  git_commit_hash:
+    description: The git commit hash of the source repository
+    value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+
 runs:
   using: composite
   steps:

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -72,7 +72,7 @@ runs:
     shell: bash
     run: |
       cd source
-      echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
+      echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Build arguments to pass to the Docker build
     default: ""
     type: string
-    required: false  
+    required: false
   target_tag:
     description: Docker hub tag to push to
     type: string
@@ -51,6 +51,14 @@ inputs:
   GOPROXY:
     required: false
 
+outputs:
+  git_commit_hash:
+    description: The git commit hash that was used to build the image
+    value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+  git_commit_hash_full:
+    description: The full git commit hash that was used to build the image
+    value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
+
 runs:
   using: composite
   steps:
@@ -78,7 +86,7 @@ runs:
     shell: bash
     id: buildx-context
     run: |
-      docker context use builders || docker context create builders 
+      docker context use builders || docker context create builders
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
     with:

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -55,9 +55,6 @@ outputs:
   git_commit_hash:
     description: The git commit hash that was used to build the image
     value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
-  git_commit_hash_full:
-    description: The full git commit hash that was used to build the image
-    value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
 
 runs:
   using: composite
@@ -76,12 +73,6 @@ runs:
     run: |
       cd source
       echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
-  - name: get full git commit hash
-    id: git_commit_hash_full
-    shell: bash
-    run: |
-      cd source
-      echo "git_commit_hash_full=$(echo $(git log --pretty=format:'%H' -n 1))" >> $GITHUB_OUTPUT
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -45,12 +45,17 @@ runs:
   steps:
   - name: Checkout this repo
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  - name: get git commit hash
+    id: git_commit_hash
+    env:
+      git_commit_hash: ${{ inputs.source_git_commit_hash }}
+    run: echo "$git_commit_hash"
   - name: Generate images list
     id: generate_images_list
     shell: bash
     run: |
       PLATFORMS='${{ inputs.platforms }}'
-      echo "Debug: Raw git_commit_hash input: '${{ needs.deploy.outputs.git_commit_hash }}'"
+
       # Iterate over the platforms and build the image list
       len=$(echo $PLATFORMS | jq '. | length')
       for ((i=0; i<$len; i++)); do
@@ -61,11 +66,11 @@ runs:
           exists=$(curl -s $url | jq '.results | length > 0')
           if [ "$exists" == "true" ]; then
             IMAGES+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug "
-            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ inputs.git_commit_hash }} "
+            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
           fi
       done
 
-      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} "
+      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
 
       IMAGES=${IMAGES::-1}  # Remove the trailing space
       echo "IMAGES: $IMAGES"
@@ -95,8 +100,8 @@ runs:
   - name: Create and push manifest images
     shell: bash
     run: |
-      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
-      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
 
   - name: Login to harbor registry
     if: ${{ inputs.harbor_registry != '' }}

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -45,11 +45,6 @@ runs:
   steps:
   - name: Checkout this repo
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  - name: get git commit hash
-    id: git_commit_hash
-    env:
-      git_commit_hash: ${{ inputs.source_git_commit_hash }}
-    run: echo "$git_commit_hash"
   - name: Generate images list
     id: generate_images_list
     shell: bash
@@ -66,11 +61,11 @@ runs:
           exists=$(curl -s $url | jq '.results | length > 0')
           if [ "$exists" == "true" ]; then
             IMAGES+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug "
-            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
+            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ inputs.git_commit_hash }} "
           fi
       done
 
-      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
+      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} "
 
       IMAGES=${IMAGES::-1}  # Remove the trailing space
       echo "IMAGES: $IMAGES"
@@ -100,8 +95,8 @@ runs:
   - name: Create and push manifest images
     shell: bash
     run: |
-      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
-      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
 
   - name: Login to harbor registry
     if: ${{ inputs.harbor_registry != '' }}

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -50,9 +50,7 @@ runs:
     shell: bash
     run: |
       PLATFORMS='${{ inputs.platforms }}'
-      echo "Debug: Raw git_commit_hash input: '${{ inputs.git_commit_hash }}'"
-      echo "Debug: Length of git_commit_hash: ${#{{ inputs.git_commit_hash }}}"
-      echo "Debug: Is git_commit_hash empty? $([[ -z "${{ inputs.git_commit_hash }}" ]] && echo "yes" || echo "no")"
+      echo "Debug: Raw git_commit_hash input: '${{ needs.deploy.outputs.git_commit_hash }}'"
       # Iterate over the platforms and build the image list
       len=$(echo $PLATFORMS | jq '. | length')
       for ((i=0; i<$len; i++)); do

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -50,7 +50,7 @@ runs:
     shell: bash
     run: |
       PLATFORMS='${{ inputs.platforms }}'
-
+      echo "input_commit_hash: ${{ inputs.git_commit_hash }}"
       # Iterate over the platforms and build the image list
       len=$(echo $PLATFORMS | jq '. | length')
       for ((i=0; i<$len; i++)); do

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -50,7 +50,9 @@ runs:
     shell: bash
     run: |
       PLATFORMS='${{ inputs.platforms }}'
-      echo "input_commit_hash: ${{ inputs.git_commit_hash }}"
+      echo "Debug: Raw git_commit_hash input: '${{ inputs.git_commit_hash }}'"
+      echo "Debug: Length of git_commit_hash: ${#{{ inputs.git_commit_hash }}}"
+      echo "Debug: Is git_commit_hash empty? $([[ -z "${{ inputs.git_commit_hash }}" ]] && echo "yes" || echo "no")"
       # Iterate over the platforms and build the image list
       len=$(echo $PLATFORMS | jq '. | length')
       for ((i=0; i<$len; i++)); do

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: The branch, tag or SHA to checkout and build from
     type: string
     required: true
+  git_commit_hash:
+    description: The git commit hash that was used in the deploy action
+    type: string
+    required: true
   target_tag:
     description: Docker hub tag to push to
     type: string
@@ -41,18 +45,6 @@ runs:
   steps:
   - name: Checkout this repo
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  - name: Check out source repository
-    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    with:
-      repository: ${{ inputs.source_repository }}
-      path: source
-      ref: ${{ inputs.source_ref }}
-  - name: get git commit hash
-    id: git_commit_hash
-    shell: bash
-    run: |
-      cd source
-      echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
   - name: Generate images list
     id: generate_images_list
     shell: bash
@@ -69,11 +61,11 @@ runs:
           exists=$(curl -s $url | jq '.results | length > 0')
           if [ "$exists" == "true" ]; then
             IMAGES+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug "
-            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
+            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ inputs.git_commit_hash }} "
           fi
       done
 
-      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} "
+      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} "
 
       IMAGES=${IMAGES::-1}  # Remove the trailing space
       echo "IMAGES: $IMAGES"
@@ -103,8 +95,8 @@ runs:
   - name: Create and push manifest images
     shell: bash
     run: |
-      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
-      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
 
   - name: Login to harbor registry
     if: ${{ inputs.harbor_registry != '' }}

--- a/.github/workflows/build-push-armiarma.yml
+++ b/.github/workflows/build-push-armiarma.yml
@@ -3,7 +3,7 @@ name: Build armiarma docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source armiarma repository to build from
         default: ethpandaops/armiarma
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -59,7 +62,6 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
@@ -78,7 +80,10 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}
           target_repository: ethpandaops/armiarma
           platforms: ${{ needs.prepare.outputs.platforms }}
-
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
   notify:

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -62,7 +62,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-          git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -3,7 +3,7 @@ name: Build beacon-metrics-gazer image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source beacon-metrics-gazer repository to build from
         default: dapplion/beacon-metrics-gazer
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -59,6 +62,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -78,6 +82,10 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}
           target_repository: ethpandaops/beacon-metrics-gazer
           platforms: ${{ needs.prepare.outputs.platforms }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -3,7 +3,7 @@ name: Build besu docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source besu repository to build from
         default: hyperledger/besu
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -79,6 +82,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -3,7 +3,7 @@ name: Build consensus-monitor docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source consensus-monitor repository to build from
         default: ralexstokes/ethereum_consensus_monitor
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -3,7 +3,7 @@ name: Build erigon docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source erigon repository to build from
         default: erigontech/erigon
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -3,7 +3,7 @@ name: Build ethereumjs docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source ethereumjs repository to build from
         default: ethereumjs/ethereumjs-monorepo
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -79,6 +82,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -3,7 +3,7 @@ name: Build execution-monitor docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source execution-monitor repository to build from
         default: ethereum/nodemonitor
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -59,7 +62,6 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
@@ -78,7 +80,10 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}
           target_repository: ethpandaops/execution-monitor
           platforms: ${{ needs.prepare.outputs.platforms }}
-
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
   notify:

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -3,7 +3,7 @@ name: Build flashbots builder docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source flashbots repository to build from
         default: flashbots/builder
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-genesis-generator.yml
+++ b/.github/workflows/build-push-genesis-generator.yml
@@ -3,7 +3,7 @@ name: Build ethereum-genesis-generator docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source ethereum-genesis-generator repository to build from
         default: ethpandaops/ethereum-genesis-generator
         type: string
@@ -44,17 +44,20 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
           target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
-          target_repository: ethpandaops/ethereum-genesis-generator
+          target_repository: ethpandaops/genesis-generator
           platform: ${{ matrix.platform }}
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
@@ -76,8 +79,12 @@ jobs:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
           target_tag: ${{ needs.prepare.outputs.target_tag }}
-          target_repository: ethpandaops/ethereum-genesis-generator
+          target_repository: ethpandaops/genesis-generator
           platforms: ${{ needs.prepare.outputs.platforms }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
-        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -71,19 +70,6 @@ jobs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Get source repository commit hash
-        id: get_commit_hash
-        run: |
-          git clone ${{ inputs.repository }} source
-          cd source
-          git checkout ${{ inputs.ref }}
-          echo "Debug: Repository: ${{ inputs.repository }}"
-          echo "Debug: Ref: ${{ inputs.ref }}"
-          echo "Debug: Current directory: $(pwd)"
-          echo "Debug: Git status: $(git status)"
-          echo "Debug: Git log: $(git log -1)"
-          echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
-          echo "Debug: Output git_commit_hash: $(cat $GITHUB_OUTPUT)"
       - uses: ./.github/actions/manifest
         id: manifest
         with:
@@ -95,7 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-          git_commit_hash: ${{ steps.get_commit_hash.outputs.git_commit_hash }}
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -3,7 +3,7 @@ name: Build geth docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source geth repository to build from
         default: ethereum/go-ethereum
         type: string
@@ -50,6 +50,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -70,6 +71,16 @@ jobs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get commit hash from deploy job
+        id: get_commit_hash
+        run: |
+          # Get the first successful job's commit hash
+          for job in ${{ needs.deploy.result }}; do
+            if [ "$job" == "success" ]; then
+              echo "git_commit_hash=${{ needs.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
       - uses: ./.github/actions/manifest
         id: manifest
         with:
@@ -81,6 +92,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ steps.get_commit_hash.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -71,16 +71,19 @@ jobs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Get commit hash from deploy job
+      - name: Get source repository commit hash
         id: get_commit_hash
         run: |
-          # Get the first successful job's commit hash
-          for job in ${{ needs.deploy.result }}; do
-            if [ "$job" == "success" ]; then
-              echo "git_commit_hash=${{ needs.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
-              break
-            fi
-          done
+          git clone ${{ inputs.repository }} source
+          cd source
+          git checkout ${{ inputs.ref }}
+          echo "Debug: Repository: ${{ inputs.repository }}"
+          echo "Debug: Ref: ${{ inputs.ref }}"
+          echo "Debug: Current directory: $(pwd)"
+          echo "Debug: Git status: $(git status)"
+          echo "Debug: Git log: $(git log -1)"
+          echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
+          echo "Debug: Output git_commit_hash: $(cat $GITHUB_OUTPUT)"
       - uses: ./.github/actions/manifest
         id: manifest
         with:

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -3,7 +3,7 @@ name: Build goteth docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source goteth repository to build from
         default: migalabs/goteth
         type: string
@@ -46,12 +46,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -80,6 +83,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -107,6 +110,10 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}
           target_repository: ethpandaops/grandine
           platforms: ${{ needs.prepare.outputs.platforms }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -3,7 +3,7 @@ name: Build lighthouse docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source lighthouse repository to build from
         default: sigp/lighthouse
         type: string
@@ -49,12 +49,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -85,6 +88,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -80,6 +83,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -3,7 +3,7 @@ name: Build mev-boost docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source mev-boost repository to build from
         default: flashbots/mev-boost
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -94,4 +98,4 @@ jobs:
         uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
         with:
           github-token: ${{ secrets.github_token }}
-          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }} 
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -3,7 +3,7 @@ name: Build mev-rs docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source mev-rs repository to build from
         default: ralexstokes/mev-rs
         type: string
@@ -49,12 +49,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -84,6 +87,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -3,7 +3,7 @@ name: Build nethermind docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source nethermind repository to build from
         default: nethermindeth/nethermind
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -49,12 +49,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -84,6 +87,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -3,7 +3,7 @@ name: Build reth docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source reth repository to build from
         default: paradigmxyz/reth
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -3,7 +3,7 @@ name: Build rustic-builder docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source rustic-builder repository to build from
         default: pawanjay176/rustic-builder
         type: string
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -78,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -94,4 +98,4 @@ jobs:
         uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
         with:
           github-token: ${{ secrets.github_token }}
-          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }} 
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -3,7 +3,7 @@ name: Build teku docker image
 on:
   workflow_dispatch:
     inputs:
-      repository: 
+      repository:
         description: The source teku repository to build from
         default: consensys/teku
         type: string
@@ -44,16 +44,18 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
-          repository: "${{ inputs.repository }}"
+          repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
-          build_script: ./teku/build.sh
           target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
           target_repository: ethpandaops/teku
           platform: ${{ matrix.platform }}
@@ -79,6 +81,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
This pr should fix actions like: https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/14126238063

Where there was a commit in the remote repository between the deploy and manifest action. 