### PR TITLE
feat(action.yml): add fetch-depth to checkout action to fetch all history

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -67,6 +67,7 @@ runs:
       repository: ${{ inputs.source_repository }}
       path: source
       ref: ${{ inputs.source_ref }}
+      fetch-depth: 0
   - name: get short git commit hash
     id: git_commit_hash
     shell: bash


### PR DESCRIPTION
Two things:

1. As of checkout@v4, only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Setting `fetch-depth: 0` will fetch all history for all branches and tags. See https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4

2. I suspect the issue didn't occur prior to #232 because there was no requirement on passing git commit hashes between jobs. Git commit hashes now flow from deploy → manifest, and obtaining these hashes correctly requires a non-shallow git checkout?
