### PR TITLE
feat(.github/workflows/build-push-lodestar.yml): capture commit hash before deploy to avoid race conditions

### DIFF
--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -36,16 +36,41 @@ jobs:
         uses: ./.github/actions/docker-tag
         with:
           input: ${{ inputs.docker_tag || inputs.ref }}
+
+  # This job will run before deploy and capture the exact commit hash, which can then be passed to 
+  # the manifest job. This is done to handle scenarios where there is a commit to the remote repository 
+  # between the deploy and manifest action.
+  get-commit-hash:
+    needs:
+      - prepare
+    runs-on: ubuntu-latest
+    outputs:
+      git_commit_hash: ${{ steps.get_hash.outputs.git_commit_hash }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout source repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ inputs.repository }}
+          path: source
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0 
+      - name: Get git commit hash
+        id: get_hash
+        run: |
+          cd source
+          echo "git_commit_hash=$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_OUTPUT
+        shell: bash
+
   deploy:
     needs:
       - prepare
+      - get-commit-hash
     runs-on: ${{ matrix.runner }}
     continue-on-error: true
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
-    outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -65,10 +90,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+
   manifest:
     needs:
       - prepare
       - deploy
+      - get-commit-hash
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -83,7 +110,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
+          git_commit_hash: ${{ needs.get-commit-hash.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
This commit introduces a new job, `get-commit-hash`, that runs before the `deploy` job. 

The purpose of this job is to capture the exact commit hash that will be deployed. This is important to handle scenarios where a new commit is pushed to the remote repository between the `deploy` and `manifest` actions.

Applied to lodestar for now as a test.