### PR TITLE
fix(ci): move git_commit_hash output to a dedicated step

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -55,6 +55,9 @@ outputs:
   git_commit_hash:
     description: The git commit hash of the source repository
     value: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
+  git_commit_hash_full:
+    description: The full git commit hash of the source repository
+    value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
 
 runs:
   using: composite

--- a/.github/workflows/build-push-armiarma.yml
+++ b/.github/workflows/build-push-armiarma.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -66,6 +66,14 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+
+      # This step captures the git commit hash from the deploy action for job output, which can then be
+      # used by the manifest job. This is done to handle scenarios where there is a commit to the remote
+      # repository between the deploy and manifest action.
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -68,6 +68,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -65,6 +65,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -44,12 +44,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -60,6 +63,12 @@ jobs:
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare
@@ -77,6 +86,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -65,6 +65,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -66,6 +66,11 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-genesis-generator.yml
+++ b/.github/workflows/build-push-genesis-generator.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -67,6 +67,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -44,6 +44,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -61,6 +63,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -66,6 +66,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -80,12 +80,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -102,6 +105,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare
@@ -137,6 +146,10 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}-minimal
           target_repository: ethpandaops/grandine
           platforms: ${{ needs.prepare.outputs.platforms }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-minimal.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -66,6 +66,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-minimal:
     needs:
       - prepare

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -71,6 +71,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -66,7 +66,9 @@ jobs:
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
         
-      # This step captures the git commit hash from the deploy action for job output
+      # This step captures the git commit hash from the deploy action for job output, which can then be
+      # used by the manifest job. This is done to handle scenarios where there is a commit to the remote
+      # repository between the deploy and manifest action.
       - name: Set job output
         id: set_output
         run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -69,9 +69,11 @@ jobs:
       # This step captures the git commit hash from the deploy action for job output, which can then be
       # used by the manifest job. This is done to handle scenarios where there is a commit to the remote
       # repository between the deploy and manifest action.
+      #
+      # Note: Lodestar requires us to use the full git commit hash.
       - name: Set job output
         id: set_output
-        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash_full }}" >> $GITHUB_OUTPUT
         shell: bash
   manifest:
     needs:

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -65,6 +65,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+        
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -69,11 +69,9 @@ jobs:
       # This step captures the git commit hash from the deploy action for job output, which can then be
       # used by the manifest job. This is done to handle scenarios where there is a commit to the remote
       # repository between the deploy and manifest action.
-      #
-      # Note: Lodestar requires us to use the full git commit hash.
       - name: Set job output
         id: set_output
-        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash_full }}" >> $GITHUB_OUTPUT
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
         shell: bash
   manifest:
     needs:

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -44,6 +44,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -61,6 +63,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -70,6 +70,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -44,6 +44,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -62,6 +64,10 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-beacon-minimal:
     needs:
       - prepare

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -76,12 +76,15 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -94,6 +97,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-validator:
     needs:
       - prepare
@@ -102,9 +111,12 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -117,6 +129,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-validator-minimal:
     needs:
       - prepare
@@ -125,9 +143,12 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -140,6 +161,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest-beacon:
     needs:
       - prepare
@@ -157,6 +184,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-beacon.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -177,6 +205,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-beacon-minimal.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -197,6 +226,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-validator.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -217,6 +247,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-validator-minimal.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -94,6 +95,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -128,6 +130,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -162,6 +165,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
       - uses: ./.github/actions/deploy
+        id: deploy
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
@@ -197,6 +201,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-beacon.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -217,6 +222,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-beacon-minimal.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -237,6 +243,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-validator.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -257,6 +264,7 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy-validator-minimal.outputs.git_commit_hash }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -52,6 +52,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -72,6 +74,10 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-beacon-minimal:
     needs:
       - prepare
@@ -80,6 +86,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -100,6 +108,10 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-validator:
     needs:
       - prepare
@@ -108,6 +120,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -128,6 +142,10 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   deploy-validator-minimal:
     needs:
       - prepare
@@ -136,6 +154,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -156,6 +176,10 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest-beacon:
     needs:
       - prepare

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -70,6 +70,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     outputs:
-      git_commit_hash: ${{ steps.deploy.outputs.git_commit_hash }}
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -64,6 +64,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -44,6 +44,8 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-deps
@@ -61,6 +63,12 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          
+      # This step captures the git commit hash from the deploy action for job output
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
   manifest:
     needs:
       - prepare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,12 +69,15 @@ jobs:
       matrix:
         config: ${{fromJson(inputs.platforms)}}
     runs-on: ${{ matrix.config.runner }}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/install-deps
       with:
         repository: ${{ inputs.source_repository }}
     - uses: ./.github/actions/deploy
+      id: deploy
       with:
         source_repository: ${{ inputs.source_repository }}
         source_ref: ${{ inputs.source_ref }}
@@ -88,6 +91,12 @@ jobs:
         DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
         MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
         GOPROXY: "${{ inputs.GOPROXY }}"
+        
+    # This step captures the git commit hash from the deploy action for job output
+    - name: Set job output
+      id: set_output
+      run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+      shell: bash
   mainfest:
     name: Manifest
     needs: deploy
@@ -106,3 +115,4 @@ jobs:
         HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
         DOCKER_USERNAME: "${{ inputs.DOCKER_USERNAME }}"
         DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+        git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
     outputs:
       git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
+      git_commit_hash_full: ${{ steps.set_output.outputs.git_commit_hash_full }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/install-deps
@@ -95,7 +96,9 @@ jobs:
     # This step captures the git commit hash from the deploy action for job output
     - name: Set job output
       id: set_output
-      run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+      run: |
+        echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        echo "git_commit_hash_full=${{ steps.deploy.outputs.git_commit_hash_full }}" >> $GITHUB_OUTPUT
       shell: bash
   mainfest:
     name: Manifest
@@ -115,4 +118,4 @@ jobs:
         HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
         DOCKER_USERNAME: "${{ inputs.DOCKER_USERNAME }}"
         DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-        git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
+        git_commit_hash: ${{ contains(inputs.target_repository, 'lodestar') && needs.deploy.outputs.git_commit_hash_full || needs.deploy.outputs.git_commit_hash }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,9 +96,7 @@ jobs:
     # This step captures the git commit hash from the deploy action for job output
     - name: Set job output
       id: set_output
-      run: |
-        echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
-        echo "git_commit_hash_full=${{ steps.deploy.outputs.git_commit_hash_full }}" >> $GITHUB_OUTPUT
+      run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
       shell: bash
   mainfest:
     name: Manifest
@@ -118,4 +116,4 @@ jobs:
         HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
         DOCKER_USERNAME: "${{ inputs.DOCKER_USERNAME }}"
         DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-        git_commit_hash: ${{ contains(inputs.target_repository, 'lodestar') && needs.deploy.outputs.git_commit_hash_full || needs.deploy.outputs.git_commit_hash }}
+        git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}

--- a/lodestar/build.sh
+++ b/lodestar/build.sh
@@ -5,5 +5,5 @@ cd ${SCRIPT_DIR}/../source
 
 docker build --build-arg "COMMIT=${source_git_commit_hash_full}" -t "${target_repository}:${target_tag}" .
 docker push "${target_repository}:${target_tag}"
-docker tag "${target_repository}:${target_tag}" "${target_repository}:${target_tag}-${source_git_commit_hash}"
-docker push "${target_repository}:${target_tag}-${source_git_commit_hash}"
+docker tag "${target_repository}:${target_tag}" "${target_repository}:${target_tag}-${source_git_commit_hash_full}"
+docker push "${target_repository}:${target_tag}-${source_git_commit_hash_full}"

--- a/lodestar/build.sh
+++ b/lodestar/build.sh
@@ -5,5 +5,5 @@ cd ${SCRIPT_DIR}/../source
 
 docker build --build-arg "COMMIT=${source_git_commit_hash_full}" -t "${target_repository}:${target_tag}" .
 docker push "${target_repository}:${target_tag}"
-docker tag "${target_repository}:${target_tag}" "${target_repository}:${target_tag}-${source_git_commit_hash_full}"
-docker push "${target_repository}:${target_tag}-${source_git_commit_hash_full}"
+docker tag "${target_repository}:${target_tag}" "${target_repository}:${target_tag}-${source_git_commit_hash}"
+docker push "${target_repository}:${target_tag}-${source_git_commit_hash}"


### PR DESCRIPTION
This PR fixes an issue with the git commit hash not being properly propagated from the deploy job to the manifest job in the lodestar workflow.

When a commit was made to the remote repository between the deploy and manifest actions, the manifest job would use the latest commit hash instead of the specific commit that was actually built in the deploy job, leading to inconsistencies in Docker image tags.

The fix updates the workflow to:
- Add a dedicated step that captures the git commit hash output from the deploy action
- Properly propagate this output at the job level for use by downstream jobs
- Ensure the manifest job consistently uses the same commit hash that was built, even if new commits are pushed during workflow execution