### PR TITLE
fix(action.yml): shorten git_commit_hash to 7 characters

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -76,7 +76,7 @@ runs:
     shell: bash
     run: |
       cd source
-      echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1))" >> $GITHUB_OUTPUT
+      echo "git_commit_hash=$(echo $(git log --pretty=format:'%h' -n 1 --abbrev=7))" >> $GITHUB_OUTPUT
   - name: get full git commit hash
     id: git_commit_hash_full
     shell: bash


### PR DESCRIPTION
The builder uses `git log --pretty=format:'%h' -n 1`. The `%h` placeholder in Git's pretty format outputs the abbreviated commit hash. By default, [Git determines the abbreviation length dynamically for the repository](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev​), defaulting/minimum of 7 characters.

To maintain a consistent abbrv length (e.g., 7 characters), we can explicitly set the length in our command.

`git log --pretty=format:'%h' -n 1 --abbrev=7`