### PR TITLE
Fix/Optimise dual registry use

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -172,8 +172,8 @@ runs:
       tags: |
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}
-        ${{ inputs.harbor_registry != '' && format('{0}{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, steps.git_commit_hash.outputs.git_commit_hash) || '' }}
-        ${{ inputs.harbor_registry != '' && format('{0}{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }}
+        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, steps.git_commit_hash.outputs.git_commit_hash) || '' }}
+        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }}
       push: true
       platforms: ${{ inputs.platform }}
       build-args: ${{ inputs.build_args }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -172,8 +172,8 @@ runs:
       tags: |
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}
-        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, steps.git_commit_hash.outputs.git_commit_hash) || '' }}
-        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }}
+        ${{ inputs.harbor_registry != '' && format('{0}{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, steps.git_commit_hash.outputs.git_commit_hash) || '' }}
+        ${{ inputs.harbor_registry != '' && format('{0}{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }}
       push: true
       platforms: ${{ inputs.platform }}
       build-args: ${{ inputs.build_args }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -41,6 +41,10 @@ inputs:
     type: string
     default: bazel
     required: false
+  harbor_registry:
+    description: Harbor registry to push the images to
+    type: string
+    default: ''
   # Secrets
   DOCKER_USERNAME:
     required: true
@@ -50,6 +54,10 @@ inputs:
     required: true
   GOPROXY:
     required: false
+  HARBOR_USERNAME:
+    required: true
+  HARBOR_PASSWORD:
+    required: true
 
 outputs:
   git_commit_hash:
@@ -102,6 +110,13 @@ runs:
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}
+  - name: Login to harbor registry
+    if: ${{ inputs.harbor_registry != '' }}
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+    with:
+      registry: ${{ inputs.harbor_registry }}
+      username: ${{ inputs.HARBOR_USERNAME }}
+      password: ${{ inputs.HARBOR_PASSWORD }}
   ########################
   # Build script case
   #######################
@@ -154,7 +169,11 @@ runs:
       # two tags;
       #   - $target_tag
       #   - $target_tag-commit
-      tags: ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }},${{ inputs.target_repository }}:${{ inputs.target_tag }}
+      tags: |
+        ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
+        ${{ inputs.target_repository }}:${{ inputs.target_tag }}
+        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, steps.git_commit_hash.outputs.git_commit_hash) || '' }}
+        ${{ inputs.harbor_registry != '' && format('{0}/{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }}
       push: true
       platforms: ${{ inputs.platform }}
       build-args: ${{ inputs.build_args }}

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -124,10 +124,9 @@ runs:
       # Split the original images by space and add the second registry prefix
       for image in $ORIGINAL_IMAGES; do
           # Extract the repository and tag parts
-          REPO_TAG=${image#*/}  # Remove everything before the first '/'
           
           # Add to the new images list with the second registry prefix
-          NEW_IMAGES+="$SECOND_REGISTRY/$REPO_TAG "
+          NEW_IMAGES+="$SECOND_REGISTRY/$image "
       done
 
       # Remove the trailing space

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -92,7 +92,8 @@ runs:
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}
-  - name: Create and push manifest images
+
+  - name: Create and push manifest images to dockerhub
     shell: bash
     run: |
       docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
@@ -106,32 +107,50 @@ runs:
       username: ${{ inputs.HARBOR_USERNAME }}
       password: ${{ inputs.HARBOR_PASSWORD }}
 
-  - name: Create and push manifest images for other registry
+  - name: Prefix Images with Harbor registry
+    if: ${{ inputs.harbor_registry != '' }}
+    shell: bash
+    id: harbor_prefix
+    run: |
+      #!/bin/bash
+
+      # Get the original images list (assuming it's passed as an argument or environment variable)
+      ORIGINAL_IMAGES="${{ steps.generate_images_list.outputs.images }}"
+      SECOND_REGISTRY="${{ inputs.harbor_registry }}"
+
+      # Initialize the new images list
+      NEW_IMAGES=""
+
+      # Split the original images by space and add the second registry prefix
+      for image in $ORIGINAL_IMAGES; do
+          # Extract the repository and tag parts
+          REPO_TAG=${image#*/}  # Remove everything before the first '/'
+          
+          # Add to the new images list with the second registry prefix
+          NEW_IMAGES+="$SECOND_REGISTRY/$REPO_TAG "
+      done
+
+      # Remove the trailing space
+      NEW_IMAGES=${NEW_IMAGES::-1}
+
+      echo "ORIGINAL_IMAGES: $ORIGINAL_IMAGES"
+      echo "PREFIXED_IMAGES: $NEW_IMAGES"
+      echo "prefixed_images=$NEW_IMAGES" >> $GITHUB_OUTPUT
+
+
+  - name: Create and push manifest images to Harbor
     if: ${{ inputs.harbor_registry != '' }}
     shell: bash
     run: |
-      images="${{ steps.generate_images_list.outputs.tags }}"
-      for image in $images; do
-        target_tag=$(echo "${{ inputs.harbor_registry }}$image" | sed -E 's/^\s*.*:\/\///g')
-        echo "Checking if $image is available on Docker Hub..."
-        retries=10
-        delay=30
-        until [[ $retries -le 0 ]]; do
-          if docker manifest inspect $image > /dev/null 2>&1; then
-            echo "$image is available on Docker Hub."
-            echo "Copying $image to $target_tag"
-            docker buildx imagetools create --dry-run -t $target_tag $image
-            docker buildx imagetools create -t $target_tag $image
-            break
-          else
-            echo "$image is not yet available on Docker Hub. Retrying in $delay seconds..."
-            sleep $delay
-            ((retries--))
-          fi
-        done
-        if [[ $retries -le 0 ]]; then
-          echo "Failed to find $image on Docker Hub after multiple attempts."
-          echo "Skipping $image"
-          continue
-        fi
-      done
+      # Dry run first
+      docker buildx imagetools create --dry-run \
+        ${{ format('-t {0}/{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }} \
+        ${{ format('-t {0}/{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, inputs.git_commit_hash) || '' }} \
+        ${{ steps.harbor_prefix.outputs.prefixed_images }}
+      
+      # Actual creation
+      docker buildx imagetools create \
+        ${{ format('-t {0}/{1}:{2}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag) || '' }} \
+        ${{ format('-t {0}/{1}:{2}-{3}', inputs.harbor_registry, inputs.target_repository, inputs.target_tag, inputs.git_commit_hash) || '' }} \
+        ${{ steps.harbor_prefix.outputs.prefixed_images }}
+

--- a/.github/workflows/build-push-armiarma.yml
+++ b/.github/workflows/build-push-armiarma.yml
@@ -66,6 +66,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output, which can then be
       # used by the manifest job. This is done to handle scenarios where there is a commit to the remote

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -68,6 +68,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -63,6 +63,9 @@ jobs:
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -59,11 +59,14 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
           target_repository: ethpandaops/erigon
           platform: ${{ matrix.platform }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output
@@ -91,17 +94,17 @@ jobs:
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-  notify:
-    name: Discord Notification
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - deploy
-      - manifest
-    if: failure()
-    steps:
-      - name: Notify
-        uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
-        with:
-          github-token: ${{ secrets.github_token }}
-          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
+  #notify:
+  #  name: Discord Notification
+  #  runs-on: ubuntu-latest
+  #  needs:
+  #    - prepare
+  #    - deploy
+  #    - manifest
+  #  if: failure()
+  #  steps:
+  #    - name: Notify
+  #      uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
+  #      with:
+  #        github-token: ${{ secrets.github_token }}
+  #        discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -59,7 +59,6 @@ jobs:
           target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
           target_repository: ethpandaops/erigon
           platform: ${{ matrix.platform }}
-          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
@@ -67,6 +66,7 @@ jobs:
           GOPROXY: "${{ vars.GOPROXY }}"
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -94,17 +94,17 @@ jobs:
 
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-  #notify:
-  #  name: Discord Notification
-  #  runs-on: ubuntu-latest
-  #  needs:
-  #    - prepare
-  #    - deploy
-  #    - manifest
-  #  if: failure()
-  #  steps:
-  #    - name: Notify
-  #      uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
-  #      with:
-  #        github-token: ${{ secrets.github_token }}
-  #        discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - deploy
+      - manifest
+    if: failure()
+    steps:
+      - name: Notify
+        uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
+        with:
+          github-token: ${{ secrets.github_token }}
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build-push-eth-das-guardian.yml
+++ b/.github/workflows/build-push-eth-das-guardian.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-ethereum-genesis-generator.yml
+++ b/.github/workflows/build-push-ethereum-genesis-generator.yml
@@ -67,6 +67,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-ethrex.yml
+++ b/.github/workflows/build-push-ethrex.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -66,6 +66,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output
         id: set_output

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
   manifest:
     needs:
       - prepare

--- a/.github/workflows/build-push-goevmlab.yml
+++ b/.github/workflows/build-push-goevmlab.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -66,6 +66,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -72,6 +72,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -71,6 +71,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
         
       # This step captures the git commit hash from the deploy action for job output, which can then be
       # used by the manifest job. This is done to handle scenarios where there is a commit to the remote

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -70,6 +70,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -75,6 +75,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
       - name: Set job output
         id: set_output
         run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -70,6 +70,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -65,6 +65,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -64,6 +64,9 @@ jobs:
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
           GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
 
       # This step captures the git commit hash from the deploy action for job output
       - name: Set job output


### PR DESCRIPTION
- Fixes the manifest uploads to harbor
- Moved the docker push of the actual images to harbor to the build step to avoid unnecessary traffic caused by downloading from dockerhub during the manifest run

Tested only with Erigon. 
successful run in fork: https://github.com/EthDevOps/eth-client-docker-image-builder/actions/runs/15489476809

