### PR TITLE
feat(prysm): compatible symlink on same path as official prysm images

### DIFF
--- a/prysm/Dockerfile.beacon
+++ b/prysm/Dockerfile.beacon
@@ -4,6 +4,7 @@ ARG ENTRY=/app/cmd/beacon-chain/beacon-chain
 ENV ENTRY=${ENTRY}
 WORKDIR /app/cmd/beacon-chain/beacon-chain.runfiles/prysm
 ADD ./_beacon-chain /app/cmd/beacon-chain/beacon-chain
+RUN ln -s /app/cmd/beacon-chain/beacon-chain /beacon-chain
 ADD ./entrypoint.sh /entrypoint.sh
 RUN apt-get update && apt-get install -y ca-certificates libc6 && update-ca-certificates
 

--- a/prysm/Dockerfile.validator
+++ b/prysm/Dockerfile.validator
@@ -4,6 +4,7 @@ ARG ENTRY=/app/cmd/validator/validator
 ENV ENTRY=${ENTRY}
 WORKDIR /app/cmd/validator/validator.runfiles/prysm
 ADD ./_validator /app/cmd/validator/validator
+RUN ln -s /app/cmd/validator/validator /validator
 ADD ./entrypoint.sh /entrypoint.sh
 RUN apt-get update && apt-get install -y ca-certificates libc6 && update-ca-certificates
 


### PR DESCRIPTION
The official beacon image has the binary in `/beacon-chain` and the validator image on `/validator`. 