### PR TITLE
fix: Use rust:1.89-bookworm image for reth-rbuilder

### DIFF
--- a/reth-rbuilder/Dockerfile.rbuilder
+++ b/reth-rbuilder/Dockerfile.rbuilder
@@ -9,7 +9,7 @@
 ARG FEATURES
 ARG RBUILDER_BIN="rbuilder"
 
-FROM rust:1.89 AS base
+FROM rust:1.89-bookworm AS base
 ARG TARGETPLATFORM
 
 RUN apt-get update \


### PR DESCRIPTION
Pick up fix from: https://github.com/flashbots/rbuilder/pull/796