### PR TITLE
feat(reth): custom build arguments

### DIFF
--- a/generate_config.py
+++ b/generate_config.py
@@ -45,7 +45,8 @@ DEFAULT_REPOS = {
 # Build argument defaults for special cases
 BUILD_ARGS = {
     'mev-rs/main-minimal': 'FEATURES=minimal-preset',
-    'reth-rbuilder/develop': 'RBUILDER_BIN=reth-rbuilder'
+    'reth-rbuilder/develop': 'RBUILDER_BIN=reth-rbuilder',
+    'paradigmxyz/reth': 'FEATURES=asm-keccak,BUILD_PROFILE=maxperf'
 }
 
 # Clients that need to have minimal builds created automatically


### PR DESCRIPTION
For max performance, Reth should be built with `asm-keccak` feature and in `maxperf` profile.