### PR TITLE
Prysm: Add `optional-proofs` branch

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -108,6 +108,7 @@ prysm:
     - rebased-partial-columns
     - prysm/partial-cells-current
     - epbs-devnet-1
+    - optional-proofs
   alt_repos:
     MarcoPolo/prysm:
       - partial-columns


### PR DESCRIPTION
This corresponds to:
- https://github.com/OffchainLabs/prysm/pull/16352

for [EIP-8025](https://eips.ethereum.org/EIPS/eip-8025) 