### PR TITLE
Lighthouse: use upstream Dockerfile for eth-act/optional-proofs

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -61,7 +61,8 @@ lighthouse:
     - epbs-devnet-1
   alt_repos:
     eth-act/lighthouse:
-      - optional-proofs
+      - branch: optional-proofs
+        use_upstream_dockerfile: true
     dknopik/lighthouse:
       - partial-columns
 

--- a/generate_config.py
+++ b/generate_config.py
@@ -152,8 +152,20 @@ def generate_config():
                 prefix = repo_parts[0].lower()
 
                 for branch_spec in branches:
+                    # Dict form allows per-branch options (e.g. use_upstream_dockerfile)
+                    if isinstance(branch_spec, dict):
+                        branch = branch_spec['branch']
+                        use_upstream_dockerfile = branch_spec.get('use_upstream_dockerfile', False)
+                        safe_branch_name = branch.replace('/', '-')
+                        target_tag = f"{prefix}-{safe_branch_name}"
+                        process_branch(client_name, alt_repo, branch, target_tag, config_list,
+                                       use_upstream_dockerfile=use_upstream_dockerfile)
+
+                        if client_name in MINIMAL_VARIANTS:
+                            process_branch(client_name, alt_repo, branch, f"{prefix}-{safe_branch_name}-minimal",
+                                           config_list, use_upstream_dockerfile=use_upstream_dockerfile)
                     # Check if this is a branch with special tag
-                    if '@' in branch_spec:
+                    elif '@' in branch_spec:
                         branch, special_tag = branch_spec.split('@', 1)
                         # Create the target tag with prefix and special tag
                         target_tag = f"{prefix}-{special_tag}"
@@ -314,7 +326,7 @@ def get_build_args(client_name, source_repo, branch, target_tag):
 
     return None
 
-def process_branch(client_name, source_repo, branch, target_tag, config_list):
+def process_branch(client_name, source_repo, branch, target_tag, config_list, use_upstream_dockerfile=False):
     """Process a single branch configuration"""
     # Create the basic configuration
     config = {
@@ -328,10 +340,12 @@ def process_branch(client_name, source_repo, branch, target_tag, config_list):
         }
     }
 
-    # Add dockerfile if one exists for this client
-    dockerfile_path = get_dockerfile_path(client_name, target_tag)
-    if dockerfile_path:
-        config['target']['dockerfile'] = dockerfile_path
+    # Add dockerfile if one exists for this client, unless the source repo's
+    # own Dockerfile should be used instead
+    if not use_upstream_dockerfile:
+        dockerfile_path = get_dockerfile_path(client_name, target_tag)
+        if dockerfile_path:
+            config['target']['dockerfile'] = dockerfile_path
 
     # Add build script if one exists for this client/branch combination
     build_script = get_build_script(client_name, branch, target_tag)


### PR DESCRIPTION
## Summary
- Adds `use_upstream_dockerfile` option to `alt_repos` branch entries in `branches.yaml` via a dict-form spec.
- When set, `generate_config.py` skips injecting the local Dockerfile path so the source repo's own Dockerfile is used instead.
- Applies this to `eth-act/lighthouse:optional-proofs`, which ships its own Dockerfile upstream.

## Test plan
- [x] `python3 generate_config.py` regenerates `config.yaml`; the `eth-act-optional-proofs` entry no longer has a `dockerfile:` field.
- [x] Other lighthouse entries (e.g. `dknopik-partial-columns`) still pin to `./lighthouse/Dockerfile`.
- [x] `yamale -s schema.yaml config.yaml` passes.
- [ ] Scheduled build of `ethpandaops/lighthouse:eth-act-optional-proofs` succeeds using the upstream Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)