### PR TITLE
Lighthouse: ship local Dockerfile for eth-act/optional-proofs

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -61,8 +61,7 @@ lighthouse:
     - epbs-devnet-1
   alt_repos:
     eth-act/lighthouse:
-      - branch: optional-proofs
-        use_upstream_dockerfile: true
+      - optional-proofs
     dknopik/lighthouse:
       - partial-columns
 

--- a/generate_config.py
+++ b/generate_config.py
@@ -152,20 +152,8 @@ def generate_config():
                 prefix = repo_parts[0].lower()
 
                 for branch_spec in branches:
-                    # Dict form allows per-branch options (e.g. use_upstream_dockerfile)
-                    if isinstance(branch_spec, dict):
-                        branch = branch_spec['branch']
-                        use_upstream_dockerfile = branch_spec.get('use_upstream_dockerfile', False)
-                        safe_branch_name = branch.replace('/', '-')
-                        target_tag = f"{prefix}-{safe_branch_name}"
-                        process_branch(client_name, alt_repo, branch, target_tag, config_list,
-                                       use_upstream_dockerfile=use_upstream_dockerfile)
-
-                        if client_name in MINIMAL_VARIANTS:
-                            process_branch(client_name, alt_repo, branch, f"{prefix}-{safe_branch_name}-minimal",
-                                           config_list, use_upstream_dockerfile=use_upstream_dockerfile)
                     # Check if this is a branch with special tag
-                    elif '@' in branch_spec:
+                    if '@' in branch_spec:
                         branch, special_tag = branch_spec.split('@', 1)
                         # Create the target tag with prefix and special tag
                         target_tag = f"{prefix}-{special_tag}"
@@ -260,6 +248,13 @@ def get_dockerfile_path(client_name, target_tag=None):
             return f"./{client_name}/Dockerfile.minimal"
         return f"./{client_name}/Dockerfile"
 
+    # Prefer a per-tag Dockerfile if one is shipped alongside the default
+    # (e.g. ./lighthouse/Dockerfile.eth-act-optional-proofs)
+    if target_tag:
+        tagged_path = f"./{client_name}/Dockerfile.{target_tag}"
+        if os.path.exists(tagged_path):
+            return tagged_path
+
     # Base path is usually the client directory with a Dockerfile
     default_path = f"./{client_name}/Dockerfile"
 
@@ -326,7 +321,7 @@ def get_build_args(client_name, source_repo, branch, target_tag):
 
     return None
 
-def process_branch(client_name, source_repo, branch, target_tag, config_list, use_upstream_dockerfile=False):
+def process_branch(client_name, source_repo, branch, target_tag, config_list):
     """Process a single branch configuration"""
     # Create the basic configuration
     config = {
@@ -340,12 +335,10 @@ def process_branch(client_name, source_repo, branch, target_tag, config_list, us
         }
     }
 
-    # Add dockerfile if one exists for this client, unless the source repo's
-    # own Dockerfile should be used instead
-    if not use_upstream_dockerfile:
-        dockerfile_path = get_dockerfile_path(client_name, target_tag)
-        if dockerfile_path:
-            config['target']['dockerfile'] = dockerfile_path
+    # Add dockerfile if one exists for this client
+    dockerfile_path = get_dockerfile_path(client_name, target_tag)
+    if dockerfile_path:
+        config['target']['dockerfile'] = dockerfile_path
 
     # Add build script if one exists for this client/branch combination
     build_script = get_build_script(client_name, branch, target_tag)

--- a/lighthouse/Dockerfile.eth-act-optional-proofs
+++ b/lighthouse/Dockerfile.eth-act-optional-proofs
@@ -1,0 +1,28 @@
+FROM rust:1.88.0-bullseye AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends cmake libclang-dev clang \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+ENV CC=clang
+ENV CXX=clang++
+ARG FEATURES
+ARG PROFILE=release
+ARG CARGO_USE_GIT_CLI=true
+ENV FEATURES=$FEATURES
+ENV PROFILE=$PROFILE
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
+ENV CARGO_INCREMENTAL=1
+
+WORKDIR /lighthouse
+COPY . .
+# Persist the registry and target file across builds. See: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/lighthouse/target \
+    make
+
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libssl-dev \
+  ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse


### PR DESCRIPTION
## Summary
- Reverts the `use_upstream_dockerfile` flag from #350 to stay consistent with every other build (all Dockerfiles live in this repo).
- Copies the Dockerfile from `eth-act/lighthouse:optional-proofs` into `./lighthouse/Dockerfile.eth-act-optional-proofs`.
- `generate_config.py` now auto-detects `./{client}/Dockerfile.{tag}` and uses it when present; otherwise falls back to the default `./{client}/Dockerfile`. No branches.yaml schema change needed.

## Test plan
- [x] `python3 generate_config.py` regenerates `config.yaml`; the `eth-act-optional-proofs` entry points at `./lighthouse/Dockerfile.eth-act-optional-proofs`.
- [x] Other lighthouse entries (e.g. `dknopik-partial-columns`, `stable`, `unstable`) still pin to the default `./lighthouse/Dockerfile`.
- [x] `yamale -s schema.yaml config.yaml` passes.
- [ ] Scheduled build of `ethpandaops/lighthouse:eth-act-optional-proofs` succeeds with the new Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)