### PR TITLE
Lighthouse: auto-resolve per-tag Dockerfile on workflow_dispatch

### DIFF
--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
+      target_dockerfile: ${{ steps.dockerfile.outputs.target_dockerfile }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare Matrix
@@ -44,6 +45,16 @@ jobs:
           repository: ${{ inputs.repository }}
           upstream_repository: sigp/lighthouse
           docker_tag: ${{ inputs.docker_tag }}
+      - name: Resolve target dockerfile
+        id: dockerfile
+        shell: bash
+        run: |
+          candidate="./lighthouse/Dockerfile.${{ steps.tag.outputs.docker_tag }}"
+          if [ -f "$candidate" ]; then
+            echo "target_dockerfile=$candidate" >> "$GITHUB_OUTPUT"
+          else
+            echo "target_dockerfile=./lighthouse/Dockerfile" >> "$GITHUB_OUTPUT"
+          fi
   deploy:
     needs:
       - prepare
@@ -66,7 +77,7 @@ jobs:
           source_ref: ${{ inputs.ref }}
           target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
           target_repository: ethpandaops/lighthouse
-          target_dockerfile: ./lighthouse/Dockerfile
+          target_dockerfile: ${{ needs.prepare.outputs.target_dockerfile }}
           platform: ${{ matrix.platform }}
           build_args: ${{ inputs.build_args }}
 


### PR DESCRIPTION
## Summary
- Manually dispatching `build-push-lighthouse.yml` for `eth-act/lighthouse`@`optional-proofs` failed because the workflow hardcoded `./lighthouse/Dockerfile`, running the upstream `cd lighthouse && make` instead of the eth-act `Dockerfile.eth-act-optional-proofs` ([failed run](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/24455321029)).
- The scheduled path already handles this: `generate_config.py:253-256` picks `./<client>/Dockerfile.<target_tag>` when that file exists. This PR applies the same convention at dispatch time.
- If `./lighthouse/Dockerfile.<resolved-tag>` exists, use it; otherwise fall back to `./lighthouse/Dockerfile`. Existing dispatches (e.g. `sigp/lighthouse`@`stable`) are unchanged because no matching per-tag file exists.

## Test plan
- [ ] Re-dispatch `eth-act/lighthouse`@`optional-proofs` and confirm `target_dockerfile: ./lighthouse/Dockerfile.eth-act-optional-proofs` in logs
- [ ] Dispatch `sigp/lighthouse`@`stable` and confirm it still uses `./lighthouse/Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)