### PR TITLE
Auto-resolve per-tag Dockerfile in shared deploy action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -74,12 +74,32 @@ outputs:
   git_commit_hash_full:
     description: The full git commit hash of the source repository
     value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
+  resolved_dockerfile:
+    description: Dockerfile path actually used (after per-tag convention resolution)
+    value: ${{ steps.resolve_dockerfile.outputs.dockerfile }}
 
 runs:
   using: composite
   steps:
   - name: Checkout this repo
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  - name: Resolve target dockerfile (prefer ./<client>/Dockerfile.<tag>)
+    id: resolve_dockerfile
+    shell: bash
+    env:
+      TARGET_DOCKERFILE: ${{ inputs.target_dockerfile }}
+      TARGET_TAG: ${{ inputs.target_tag }}
+    run: |
+      resolved="$TARGET_DOCKERFILE"
+      if [ -n "$TARGET_DOCKERFILE" ] && [ "$(basename "$TARGET_DOCKERFILE")" = "Dockerfile" ]; then
+        base_tag="${TARGET_TAG%-*-*}"
+        candidate="$(dirname "$TARGET_DOCKERFILE")/Dockerfile.${base_tag}"
+        if [ -f "$candidate" ]; then
+          echo "Using per-tag Dockerfile: $candidate (base tag: $base_tag)"
+          resolved="$candidate"
+        fi
+      fi
+      echo "dockerfile=$resolved" >> "$GITHUB_OUTPUT"
   - name: Check out source repository
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
@@ -144,7 +164,7 @@ runs:
       source_ref: ${{ inputs.source_ref }}
       target_tag: ${{ inputs.target_tag }}
       target_repository: ${{ inputs.target_repository }}
-      target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
+      target_dockerfile: ${{ steps.resolve_dockerfile.outputs.dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
       source_git_commit_hash_full: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
       GOPROXY: ${{ inputs.GOPROXY }}
@@ -168,7 +188,7 @@ runs:
     if: ${{ inputs.build_script == '' }}
     shell: bash
     run: |
-      DOCKERFILE_PATH="${{ inputs.target_dockerfile }}"
+      DOCKERFILE_PATH="${{ steps.resolve_dockerfile.outputs.dockerfile }}"
       if [[ -z "$DOCKERFILE_PATH" ]]; then
         # Set to default value explicitly if input is empty
         DOCKERFILE_PATH='./source/Dockerfile'
@@ -181,7 +201,7 @@ runs:
     uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
     with:
       context: ./source
-      file: ${{ inputs.target_dockerfile }}
+      file: ${{ steps.resolve_dockerfile.outputs.dockerfile }}
       tags: |
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ Add a new image to [`config.yaml`](./config.yaml) file and it will be built on s
     dockerfile: ./lighthouse/Dockerfile # optional docker file to use, defaults to the source repository's Dockerfile
 ```
 
+## Per-tag Dockerfile convention
+
+When a build needs a different Dockerfile than the default (e.g. an alt-fork branch that doesn't work with the upstream one), drop it in alongside the default using the naming convention:
+
+```
+./<client>/Dockerfile.<target_tag>
+```
+
+Both paths apply this convention automatically:
+
+1. **Scheduled builds** (via `config.yaml` → `generate_config.py`): when a per-tag file exists, `get_dockerfile_path()` picks it up and writes `target.dockerfile` into `config.yaml`.
+2. **Manual `workflow_dispatch`** (via the shared `deploy` composite action): at build time, if `basename(target_dockerfile) == "Dockerfile"` and `./<client>/Dockerfile.<resolved-tag>` exists, the per-tag file is used; otherwise the default `./<client>/Dockerfile` is used.
+
+Example: dispatching `build-push-lighthouse.yml` with `repository=eth-act/lighthouse` and `ref=optional-proofs` resolves the tag to `eth-act-optional-proofs` and automatically picks up `./lighthouse/Dockerfile.eth-act-optional-proofs` if it exists. No workflow changes required to add a new per-tag Dockerfile.
+
+The convention is skipped when the workflow explicitly passes a non-default Dockerfile (e.g. prysm's `Dockerfile.beacon`, nimbus-eth2's `Dockerfile.beacon-minimal`), so sub-component builds are unaffected.
+
 ## Output image tags
 
 Take the following config;


### PR DESCRIPTION
## Summary
- Generalizes the `./<client>/Dockerfile.<target_tag>` convention (already used by `generate_config.py`) so it works for every `workflow_dispatch` through the shared `.github/actions/deploy` composite — no per-workflow wiring needed.
- Adds a new `Resolve target dockerfile` step that picks `./<dir>/Dockerfile.<base-tag>` if it exists; otherwise keeps the workflow-provided path untouched. The resolved path is used by both the GOPROXY injection and the `docker/build-push-action` `file:` input.
- Guarded by `basename(target_dockerfile) == "Dockerfile"` — so sub-component paths like prysm's `Dockerfile.beacon`, nimbus-eth2's `Dockerfile.beacon-minimal`, and reth-rbuilder's `Dockerfile.rbuilder` are left alone.
- Documents the convention in the README.

## Behavior matrix
- `sigp/lighthouse`@`stable` → tag `stable` → no `Dockerfile.stable` → uses `./lighthouse/Dockerfile` (unchanged)
- `eth-act/lighthouse`@`optional-proofs` → tag `eth-act-optional-proofs` → file exists → uses `./lighthouse/Dockerfile.eth-act-optional-proofs` ✨
- Prysm beacon build → passes `./prysm/Dockerfile.beacon` → basename != `Dockerfile` → skipped (unchanged)
- Any future alt-fork dispatch → automatically picks up matching per-tag file if committed

## Relation to #352
#352 fixes the same issue inline in the lighthouse workflow only. This PR supersedes it for every client. If this merges first, #352 can be closed; if #352 lands first, its inline block becomes redundant-but-harmless and can be cleaned up later.

## Test plan
- [ ] Re-dispatch `eth-act/lighthouse`@`optional-proofs`; confirm `Using per-tag Dockerfile: ./lighthouse/Dockerfile.eth-act-optional-proofs` in the step log
- [ ] Dispatch `sigp/lighthouse`@`stable`; confirm `./lighthouse/Dockerfile` is used (no per-tag file exists)
- [ ] Dispatch prysm to confirm `Dockerfile.beacon` / `Dockerfile.validator` still flow through untouched
- [ ] Trigger `scheduled.yml` and confirm nothing regresses (the scheduled path passes the already-resolved dockerfile from `config.yaml`; since `basename != "Dockerfile"` for those, the action is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)