### PR TITLE
Add optional correlation_id input to all build-push workflows

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -74,12 +74,32 @@ outputs:
   git_commit_hash_full:
     description: The full git commit hash of the source repository
     value: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
+  resolved_dockerfile:
+    description: Dockerfile path actually used (after per-tag convention resolution)
+    value: ${{ steps.resolve_dockerfile.outputs.dockerfile }}
 
 runs:
   using: composite
   steps:
   - name: Checkout this repo
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  - name: Resolve target dockerfile (prefer ./<client>/Dockerfile.<tag>)
+    id: resolve_dockerfile
+    shell: bash
+    env:
+      TARGET_DOCKERFILE: ${{ inputs.target_dockerfile }}
+      TARGET_TAG: ${{ inputs.target_tag }}
+    run: |
+      resolved="$TARGET_DOCKERFILE"
+      if [ -n "$TARGET_DOCKERFILE" ] && [ "$(basename "$TARGET_DOCKERFILE")" = "Dockerfile" ]; then
+        base_tag="${TARGET_TAG%-*-*}"
+        candidate="$(dirname "$TARGET_DOCKERFILE")/Dockerfile.${base_tag}"
+        if [ -f "$candidate" ]; then
+          echo "Using per-tag Dockerfile: $candidate (base tag: $base_tag)"
+          resolved="$candidate"
+        fi
+      fi
+      echo "dockerfile=$resolved" >> "$GITHUB_OUTPUT"
   - name: Check out source repository
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
@@ -144,7 +164,7 @@ runs:
       source_ref: ${{ inputs.source_ref }}
       target_tag: ${{ inputs.target_tag }}
       target_repository: ${{ inputs.target_repository }}
-      target_dockerfile: ${{ inputs.target_dockerfile || './source/Dockerfile' }}
+      target_dockerfile: ${{ steps.resolve_dockerfile.outputs.dockerfile || './source/Dockerfile' }}
       source_git_commit_hash: ${{ steps.git_commit_hash.outputs.git_commit_hash }}
       source_git_commit_hash_full: ${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
       GOPROXY: ${{ inputs.GOPROXY }}
@@ -168,7 +188,7 @@ runs:
     if: ${{ inputs.build_script == '' }}
     shell: bash
     run: |
-      DOCKERFILE_PATH="${{ inputs.target_dockerfile }}"
+      DOCKERFILE_PATH="${{ steps.resolve_dockerfile.outputs.dockerfile }}"
       if [[ -z "$DOCKERFILE_PATH" ]]; then
         # Set to default value explicitly if input is empty
         DOCKERFILE_PATH='./source/Dockerfile'
@@ -181,7 +201,7 @@ runs:
     uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
     with:
       context: ./source
-      file: ${{ inputs.target_dockerfile }}
+      file: ${{ steps.resolve_dockerfile.outputs.dockerfile }}
       tags: |
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
         ${{ inputs.target_repository }}:${{ inputs.target_tag }}

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -1,4 +1,5 @@
 name: Build beacon-metrics-gazer image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -1,4 +1,5 @@
 name: Build besu docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-caplin.yml
+++ b/.github/workflows/build-push-caplin.yml
@@ -1,4 +1,5 @@
 name: Build caplin docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-consensoor.yml
+++ b/.github/workflows/build-push-consensoor.yml
@@ -1,4 +1,5 @@
 name: Build consensoor docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -1,4 +1,5 @@
 name: Build consensus-monitor docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-dummy-el.yml
+++ b/.github/workflows/build-push-dummy-el.yml
@@ -1,4 +1,5 @@
 name: Build dummy-el docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -1,4 +1,5 @@
 name: Build eleel docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-ere-server-zisk.yml
+++ b/.github/workflows/build-push-ere-server-zisk.yml
@@ -1,4 +1,5 @@
 name: Build ere-server-zisk docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -1,4 +1,5 @@
 name: Build erigon docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-eth-das-guardian.yml
+++ b/.github/workflows/build-push-eth-das-guardian.yml
@@ -1,4 +1,5 @@
 name: Build eth-das-guardian docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-ethereum-genesis-generator.yml
+++ b/.github/workflows/build-push-ethereum-genesis-generator.yml
@@ -1,4 +1,5 @@
 name: Build ethereum-genesis-generator docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -1,4 +1,5 @@
 name: Build ethereumjs docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-ethrex.yml
+++ b/.github/workflows/build-push-ethrex.yml
@@ -1,4 +1,5 @@
 name: Build ethrex docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -1,4 +1,5 @@
 name: Build execution-monitor docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -1,4 +1,5 @@
 name: Build flashbots builder docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-fuzztools.yml
+++ b/.github/workflows/build-push-fuzztools.yml
@@ -1,4 +1,5 @@
 name: Build fuzztools docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -1,4 +1,5 @@
 name: Build geth docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-goevmlab.yml
+++ b/.github/workflows/build-push-goevmlab.yml
@@ -1,4 +1,5 @@
 name: Build goevmlab docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -1,4 +1,5 @@
 name: Build goomy-blob docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -1,4 +1,5 @@
 name: Build goteth docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -1,4 +1,5 @@
 name: Build grandine docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -19,6 +20,10 @@ on:
         required: false
       build_args:
         description: Additional build arguments to pass to the docker build command
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -1,4 +1,5 @@
 name: Build lighthouse docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -20,6 +21,10 @@ on:
       build_args:
         description: Build arguments to pass to the Docker build
         default: ""
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -1,4 +1,5 @@
 name: Build lodestar docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-meth.yml
+++ b/.github/workflows/build-push-meth.yml
@@ -1,4 +1,5 @@
 name: Build meth docker image (bad geth)
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -19,6 +20,10 @@ on:
         required: false
       source_patch:
         description: Optional patch to apply to the source repository before building
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -1,4 +1,5 @@
 name: Build mev-boost-relay docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -19,6 +20,10 @@ on:
         required: false
       build_args:
         description: Build arguments to pass to the docker build command
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -1,4 +1,5 @@
 name: Build mev-boost docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -22,6 +23,10 @@ on:
         type: string
         required: false
         default: ""
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
+        type: string
+        required: false
 
 jobs:
   prepare:

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -1,4 +1,5 @@
 name: Build mev-rs docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -20,6 +21,10 @@ on:
       build_args:
         description: Build arguments to pass to the Docker build
         default: ""
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -1,4 +1,5 @@
 name: Build nethermind docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-nevermind.yml
+++ b/.github/workflows/build-push-nevermind.yml
@@ -1,4 +1,5 @@
 name: Build nevermind docker image (bad nethermind)
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -19,6 +20,10 @@ on:
         required: false
       source_patch:
         description: Optional patch to apply to the source repository before building
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -1,4 +1,5 @@
 name: Build nimbus-eth1 docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -1,4 +1,5 @@
 name: Build nimbus-eth2 docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -1,4 +1,5 @@
 name: Build prysm docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -25,6 +26,10 @@ on:
           - go
         default: bazel
         required: true
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
+        type: string
+        required: false
 
 jobs:
   prepare:

--- a/.github/workflows/build-push-ream.yml
+++ b/.github/workflows/build-push-ream.yml
@@ -1,4 +1,5 @@
 name: Build ream docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -1,4 +1,5 @@
 name: Build reth-rbuilder docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -20,6 +21,10 @@ on:
       build_args:
         description: Build arguments to pass to the Docker build
         default: "RBUILDER_BIN=reth-rbuilder"
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -1,4 +1,5 @@
 name: Build reth docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -1,4 +1,5 @@
 name: Build rustic-builder docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-slashoor.yml
+++ b/.github/workflows/build-push-slashoor.yml
@@ -1,4 +1,5 @@
 name: Build slashoor docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-syncoor.yml
+++ b/.github/workflows/build-push-syncoor.yml
@@ -1,4 +1,5 @@
 name: Build syncoor docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -1,4 +1,5 @@
 name: Build teku docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -1,4 +1,5 @@
 name: Build tx-fuzz docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-vibehouse.yml
+++ b/.github/workflows/build-push-vibehouse.yml
@@ -1,4 +1,5 @@
 name: Build vibehouse docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -20,6 +21,10 @@ on:
       build_args:
         description: Build arguments to pass to the Docker build
         default: ""
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/.github/workflows/build-push-zeam.yml
+++ b/.github/workflows/build-push-zeam.yml
@@ -1,4 +1,5 @@
 name: Build zeam docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,6 +16,10 @@ on:
         required: true
       docker_tag:
         description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
         type: string
         required: false
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ Add a new image to [`config.yaml`](./config.yaml) file and it will be built on s
     dockerfile: ./lighthouse/Dockerfile # optional docker file to use, defaults to the source repository's Dockerfile
 ```
 
+## Per-tag Dockerfile convention
+
+When a build needs a different Dockerfile than the default (e.g. an alt-fork branch that doesn't work with the upstream one), drop it in alongside the default using the naming convention:
+
+```
+./<client>/Dockerfile.<target_tag>
+```
+
+Both paths apply this convention automatically:
+
+1. **Scheduled builds** (via `config.yaml` → `generate_config.py`): when a per-tag file exists, `get_dockerfile_path()` picks it up and writes `target.dockerfile` into `config.yaml`.
+2. **Manual `workflow_dispatch`** (via the shared `deploy` composite action): at build time, if `basename(target_dockerfile) == "Dockerfile"` and `./<client>/Dockerfile.<resolved-tag>` exists, the per-tag file is used; otherwise the default `./<client>/Dockerfile` is used.
+
+Example: dispatching `build-push-lighthouse.yml` with `repository=eth-act/lighthouse` and `ref=optional-proofs` resolves the tag to `eth-act-optional-proofs` and automatically picks up `./lighthouse/Dockerfile.eth-act-optional-proofs` if it exists. No workflow changes required to add a new per-tag Dockerfile.
+
+The convention is skipped when the workflow explicitly passes a non-default Dockerfile (e.g. prysm's `Dockerfile.beacon`, nimbus-eth2's `Dockerfile.beacon-minimal`), so sub-component builds are unaffected.
+
 ## Output image tags
 
 Take the following config;


### PR DESCRIPTION
## Summary

- Adds an optional `correlation_id` input to every `build-push-*.yml` workflow (42 files)
- Sets `run-name:` on each so the correlation ID (when provided) is surfaced in the run list

## Why

External integrations that dispatch these workflows — notably the [panda-pulse](https://github.com/ethpandaops/panda-pulse) Discord bot's `/build` command — currently have no reliable way to find the run they just triggered. The `workflow_dispatch` REST API doesn't return a run ID, and filtering the runs list by `actor` doesn't help because every dispatch shares the same bot account. That means the bot can't follow up with build-complete notifications.

With this change an integration can pass a UUID as `correlation_id`, then list the workflow's runs and match on `run.name` / `display_title` to identify its own dispatch exactly. The input is a no-op for the build itself and defaults to empty, so manual dispatches are unaffected (run-name stays clean when the field is blank).

## Test plan

- [ ] Manually dispatch one of the updated workflows from the Actions tab without a correlation ID and verify the run-name shows `<repo>@<ref>` as expected
- [ ] Manually dispatch the same workflow with a correlation ID like `test-123` and verify the run-name shows `<repo>@<ref> [test-123]`
- [ ] Confirm existing automations that use defaults (`scheduled.yml`, `deploy.yml`) still dispatch successfully