### PR TITLE
Validate source repository and ref in prepare job

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,6 +4,12 @@ inputs:
   client:
     description: 'The client'
     required: true
+  repository:
+    description: 'Source repository to validate (e.g. owner/repo). If omitted, validation is skipped.'
+    required: false
+  ref:
+    description: 'Branch, tag, or commit SHA to validate against the source repository.'
+    required: false
 outputs:
   platforms:
     description: "Matrix of platforms and runner to use"
@@ -14,6 +20,28 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - uses: mikefarah/yq@6609ed76ecb69f9d8254345292d90ea72f641715 # v4.35.1
+    - name: Validate source repository and ref exist
+      if: inputs.repository != '' && inputs.ref != ''
+      shell: bash
+      env:
+        SOURCE_REPOSITORY: ${{ inputs.repository }}
+        SOURCE_REF: ${{ inputs.ref }}
+        GIT_TERMINAL_PROMPT: '0'
+      run: |
+        url="https://github.com/${SOURCE_REPOSITORY}.git"
+        if [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]+$ ]]; then
+          tmp=$(mktemp -d)
+          git -C "$tmp" init -q
+          if ! git -C "$tmp" fetch --depth=1 "$url" "$SOURCE_REF" >/dev/null 2>&1; then
+            echo "::error::Commit '$SOURCE_REF' not found in repository '$SOURCE_REPOSITORY'"
+            exit 1
+          fi
+        else
+          if ! git ls-remote --exit-code "$url" "$SOURCE_REF" >/dev/null 2>&1; then
+            echo "::error::Ref '$SOURCE_REF' not found in repository '$SOURCE_REPOSITORY'"
+            exit 1
+          fi
+        fi
     - name: Generate platform and runner matrix from config files
       id: setup_platforms
       shell: bash

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'beacon-metrics-gazer'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'besu'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-caplin.yml
+++ b/.github/workflows/build-push-caplin.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'caplin'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-consensoor.yml
+++ b/.github/workflows/build-push-consensoor.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'consensoor'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'consensus-monitor'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-dummy-el.yml
+++ b/.github/workflows/build-push-dummy-el.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'dummy-el'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'eleel'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-ere-server-zisk.yml
+++ b/.github/workflows/build-push-ere-server-zisk.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'ere-server-zisk'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'erigon'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-eth-das-guardian.yml
+++ b/.github/workflows/build-push-eth-das-guardian.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'eth-das-guardian'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-ethereum-genesis-generator.yml
+++ b/.github/workflows/build-push-ethereum-genesis-generator.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'ethereum-genesis-generator'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'ethereumjs'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-ethrex.yml
+++ b/.github/workflows/build-push-ethrex.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'ethrex'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'execution-monitor'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'flashbots-builder'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-fuzztools.yml
+++ b/.github/workflows/build-push-fuzztools.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'fuzztools'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'geth'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-goevmlab.yml
+++ b/.github/workflows/build-push-goevmlab.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'goevmlab'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'goomy-blob'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -38,6 +38,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'goteth'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -40,6 +40,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'grandine'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'lighthouse'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'lodestar'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-meth.yml
+++ b/.github/workflows/build-push-meth.yml
@@ -40,6 +40,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'meth'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -40,6 +40,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'mev-boost-relay'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'mev-boost'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'mev-rs'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'nethermind'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-nevermind.yml
+++ b/.github/workflows/build-push-nevermind.yml
@@ -40,6 +40,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'nevermind'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'nimbus-eth1'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'nimbus-eth2'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -44,6 +44,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'prysm-beacon-chain'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-ream.yml
+++ b/.github/workflows/build-push-ream.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'ream'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'reth-rbuilder'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'reth'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'rustic-builder'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-slashoor.yml
+++ b/.github/workflows/build-push-slashoor.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'slashoor'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-syncoor.yml
+++ b/.github/workflows/build-push-syncoor.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'syncoor'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'teku'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'tx-fuzz'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-vibehouse.yml
+++ b/.github/workflows/build-push-vibehouse.yml
@@ -41,6 +41,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'vibehouse'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag

--- a/.github/workflows/build-push-zeam.yml
+++ b/.github/workflows/build-push-zeam.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           client: 'zeam'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
       - name: Generate target tag
         id: tag
         uses: ./.github/actions/docker-tag


### PR DESCRIPTION
## Summary
- Probe the source repo + ref in the `prepare` job so that bad input (nonexistent repository, deleted branch, typo'd tag, unreachable commit) fails fast — before the matrix fans out to parallel deploy runners.
- `prepare` composite action now accepts optional `repository` and `ref` inputs. When both are set, it runs `git ls-remote --exit-code <url> <ref>` for branch/tag names, and falls back to a shallow `git fetch` probe when the ref looks like a commit SHA (`^[0-9a-fA-F]+$`).
- All 42 `build-push-*` workflows updated to pass `inputs.repository` + `inputs.ref` through to `prepare`. Inputs are optional so the action stays backward-compatible for any external callers.
- `GIT_TERMINAL_PROMPT=0` is set so the step can't hang on auth prompts for private/nonexistent repos.

## Motivation
Today, when the bot dispatches a workflow with a bad ref or repo, the `prepare` job succeeds and each matrix leg independently fails at the source checkout step — including slower self-hosted macOS/ARM runners that may queue first. The caller sees N noisy late failures instead of one early error.

## Test plan
- [ ] Dispatch any `build-push-*` workflow with a valid repo/ref → prepare job succeeds, matrix runs as before.
- [ ] Dispatch with a nonexistent branch (e.g. `ref: does-not-exist`) → prepare job fails with a clear `::error::` annotation, no matrix jobs spawn.
- [ ] Dispatch with a nonexistent repo → prepare job fails with a clear `::error::` annotation.
- [ ] Dispatch with a valid commit SHA → prepare job succeeds (fetch path exercised).
- [ ] Dispatch with a garbage SHA (e.g. `deadbeefdeadbeef`) → prepare job fails.