### PR TITLE
Pin nimbus-eth2 Dockerfiles to debian:trixie-slim

### DIFF
--- a/nimbus-eth2/Dockerfile.beacon
+++ b/nimbus-eth2/Dockerfile.beacon
@@ -1,4 +1,4 @@
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -17,7 +17,7 @@ RUN cd /root/nimbus-eth2 \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get clean && apt update \

--- a/nimbus-eth2/Dockerfile.beacon-minimal
+++ b/nimbus-eth2/Dockerfile.beacon-minimal
@@ -1,4 +1,4 @@
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -17,7 +17,7 @@ RUN cd /root/nimbus-eth2 \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get clean && apt update \

--- a/nimbus-eth2/Dockerfile.validator
+++ b/nimbus-eth2/Dockerfile.validator
@@ -1,4 +1,4 @@
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -17,7 +17,7 @@ RUN cd /root/nimbus-eth2 \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get clean && apt update \

--- a/nimbus-eth2/Dockerfile.validator-minimal
+++ b/nimbus-eth2/Dockerfile.validator-minimal
@@ -1,4 +1,4 @@
-FROM debian:testing-slim AS build
+FROM debian:trixie-slim AS build
 
 SHELL ["/bin/bash", "-c"]
 
@@ -17,7 +17,7 @@ RUN cd /root/nimbus-eth2 \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:testing-slim as deploy
+FROM debian:trixie-slim as deploy
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get clean && apt update \


### PR DESCRIPTION
## Summary

- Pin all four `nimbus-eth2/Dockerfile.*` base images from `debian:testing-slim` → `debian:trixie-slim` (Debian 13 stable, gcc 14.2.0)
- Unblocks every scheduled nimbus-eth2 image build

## Why

`debian:testing-slim` currently ships `gcc-15` (15.2.0). Builds fail deterministically in the `nimbus_beacon_node` / `nimbus_validator_client` compile step with an LTO internal compiler error:

```
/root/nimbus-eth2/beacon_chain/nimbus_binary_common.nim:84:15: internal compiler error: Segmentation fault
   84 | proc writePanicLine*(v: varargs[string, `$`]) =
      |               ^
0x124b88f update_ssa(unsigned int)
Please submit a full bug report, with preprocessed source (by using -freport-bug).
See <file:///usr/share/doc/gcc-15/README.Bugs> for instructions.
make[2]: *** [/tmp/ccQIAbR7.mk:146: /tmp/ccJGPn5p.ltrans72.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
/usr/bin/aarch64-linux-gnu-ld.bfd: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[1]: *** [nimcache/release/nimbus_validator_client/nimbus_validator_client.makefile:2348: build] Error 1
make: *** [Makefile:449: nimbus_validator_client] Error 2
```

Real GCC 15 bug in `update_ssa` during LTO on Nim-generated C; both amd64 and arm64 (cross) hit it. Example failing run: https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/24721350367/job/72310899941

`debian:trixie-slim` ships gcc 14.2.0 — no ICE — and it's the current Debian stable, so the base image no longer rolls silently across rebuilds.

## Upstream

Proposed the same pin upstream: status-im/nimbus-eth2#8310. Once that merges we can drop this override (`ca-certificates` is also already in ours, and is folded into the upstream PR, so diff goes back to zero).

## Test plan

- [x] Trigger build-push on `bbusa/pin-debian-trixie` for nimbus-eth2 stable, stable-minimal, and one optional-proofs tag on both amd64 and arm64 — verify the compile step completes