### PR TITLE
Fix scheduled check aborting on transient curl/jq failures

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -95,8 +95,13 @@ jobs:
               local exists="unknown"
               local attempt response http_code body count
               for attempt in 1 2 3; do
-                response=$(curl -s --max-time 20 -w $'\n%{http_code}' "$URL")
-                if [ $? -ne 0 ] || [ -z "$response" ]; then
+                # `|| true` is load-bearing: the surrounding script runs under
+                # `bash -e`, which aborts the subshell on a failed command
+                # substitution — so a curl timeout here would kill the background
+                # process_image mid-function and leave an empty output file,
+                # breaking the aggregator with "bad array subscript".
+                response=$(curl -s --max-time 20 -w $'\n%{http_code}' "$URL" || true)
+                if [ -z "$response" ]; then
                   sleep $((attempt * 2))
                   continue
                 fi
@@ -106,8 +111,10 @@ jobs:
                 if [ "$http_code" = "200" ]; then
                   # Require a well-formed tags payload and exact-match the tag
                   # name so a substring hit (e.g. `foo-abc` vs `foo-abcdef`)
-                  # can't mask a missing tag.
-                  count=$(echo "$body" | jq -e --arg tag "$IMAGE_TAG" '[.results[]? | select(.name == $tag)] | length' 2>/dev/null)
+                  # can't mask a missing tag. `|| true` again: jq -e exits
+                  # non-zero on parse errors / null results and would otherwise
+                  # abort the subshell under bash -e.
+                  count=$(echo "$body" | jq -e --arg tag "$IMAGE_TAG" '[.results[]? | select(.name == $tag)] | length' 2>/dev/null || true)
                   if [ -n "$count" ]; then
                     if [ "$count" -gt 0 ]; then
                       exists=true
@@ -169,13 +176,21 @@ jobs:
 
           declare -A images
 
-          # Concatenate results, ensuring files exist before attempting to read
+          # Concatenate results, ensuring files exist before attempting to read.
+          # Skip empty / malformed files so a single aborted process_image subshell
+          # can't crash the whole check job with "bad array subscript".
           for file in $TEMP_DIR/*_image.json; do
-              if [ -f "$file" ]; then
-                  LINE=$(cat "$file" | jq -r '.line')
-                  IMAGE=$(cat "$file" | jq -r '.image')
-                  EXISTS=$(cat "$file" | jq -r '.exists')
-                  images[$IMAGE]=$EXISTS
+              if [ -f "$file" ] && [ -s "$file" ]; then
+                  LINE=$(jq -r '.line // empty' "$file" 2>/dev/null || true)
+                  IMAGE=$(jq -r '.image // empty' "$file" 2>/dev/null || true)
+                  EXISTS=$(jq -r '.exists // empty' "$file" 2>/dev/null || true)
+                  if [ -n "$IMAGE" ]; then
+                      images[$IMAGE]=$EXISTS
+                  else
+                      echo "WARN: dropping malformed image-check result $(basename "$file"): $(head -c 200 "$file")" >&2
+                  fi
+              else
+                  echo "WARN: image-check result $(basename "$file") is empty; skipping" >&2
               fi
           done
 


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced by #357 — the scheduled check now aborts with `images[\$IMAGE]: bad array subscript` whenever any background `process_image` subshell hits a curl timeout. Example failing run: [24724122514](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/24724122514/job/72320487012#step:9:204).

## Root cause

GitHub Actions invokes `run:` steps as `/usr/bin/bash -e /path/to/script.sh`. In that mode (unlike `#!/bin/bash -e` as a shebang or a `bash -c` invocation), a command substitution whose command fails aborts the surrounding subshell. The retry loop had this line:

```bash
response=$(curl -s --max-time 20 -w $'\n%{http_code}' "$URL")
if [ $? -ne 0 ] || [ -z "$response" ]; then
  ...
fi
```

When curl timed out, `response=$(...)` killed the backgrounded `process_image &` subshell **before** `$?` could be checked — the function never reached its final `echo >> $imageOutput`, so its result file stayed empty. The aggregator then ran `images[\$IMAGE]=\$EXISTS` with an empty `$IMAGE` extracted from the empty file, which bash rejects as a bad subscript under `-e`.

Same problem on `count=\$(echo "\$body" | jq -e ...)` whenever the body was not valid JSON (or jq -e output was null/false).

## Fix

`.github/workflows/scheduled.yml`:

- **`process_image`:** wrap the curl and jq -e command substitutions with `|| true` so transient failures drive the retry loop instead of aborting. Drop the now-redundant `\$? -ne 0` check — `curl -w '%{http_code}'` always writes at least `\n000`, so the empty-response guard is sufficient.
- **Aggregator:** skip empty result files (`[ -s "\$file" ]`) and JSON missing `.image`, emitting a WARN line instead of crashing. This is belt-and-suspenders: a future regression in `process_image` can no longer take down the whole check job.

## Verification

Reproduced and fixed under the exact GH Actions shell mode (`bash -e /tmp/extracted.sh`). End-to-end harness with 5 parallel calls — real tag, missing tag in existing repo, 404 on missing repo, DNS-fail, connection-refused — all produced valid result files and correct build decisions:

```
SKIP:  ethpandaops/nimbus-eth2:epbs-devnet-1-a23ebfd (present)
BUILD: ethpandaops/nimbus-eth2:definitely-missing-xxxxxxx
BUILD: ethpandaops/not-a-real-repo:foo
SKIP:  some/bad:dns (inconclusive)
SKIP:  some/bad:connrefused (inconclusive)
final exit: 0
```

Also verified the aggregator's defensive guard: tossing empty / non-JSON / missing-image-field files into the mix produces WARN lines and still exits 0.

## Test plan

- [ ] Next scheduled run completes the check job (no `bad array subscript`).
- [ ] Nimbus-eth2 `epbs-devnet-1` is not re-queued for build since the image is present.
- [ ] Any transient curl failure shows the WARN line and skips the build rather than crashing.