### PR TITLE
Stamp version info on Prysm minimal builds

### DIFF
--- a/prysm/build_beacon_minimal.sh
+++ b/prysm/build_beacon_minimal.sh
@@ -39,14 +39,14 @@ END
   "bazel")
     echo "Building with Bazel..."
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false
       fi
     fi
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain

--- a/prysm/build_validator_minimal.sh
+++ b/prysm/build_validator_minimal.sh
@@ -39,14 +39,14 @@ END
   "bazel")
     echo "Building with Bazel..."
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false
       fi
     fi
     mv bazel-bin/cmd/validator/validator_/validator _validator


### PR DESCRIPTION
## Summary
- Prysm minimal images were logging `Prysm/Unknown/Local build. Built at: Moments ago` at startup, while non-minimal images reported the proper commit/tag/date.
- Root cause: upstream `OffchainLabs/prysm/.bazelrc` sets `--stamp` under `build:release` but not under `build:minimal`. The Prysm `runtime/version` package uses Bazel `x_defs` that reference `{STABLE_GIT_COMMIT}`, `{STABLE_GIT_TAG}`, `{DATE}`, `{DATE_UNIX}` — these are only resolved by `workspace_status_command` when `--stamp` is passed. Without it, the Go vars keep their defaults (`"Unknown"`, `"Local build"`, `"Moments ago"`).
- Fix: add `--stamp` to all three bazelisk invocations in `prysm/build_beacon_minimal.sh` and `prysm/build_validator_minimal.sh` so the minimal builds embed the same version metadata as the release builds.

## Test plan
- [ ] Trigger a minimal Prysm beacon build via the builder workflow
- [ ] Run the resulting image and confirm the startup log shows the real commit hash/tag/date instead of `Prysm/Unknown/Local build. Built at: Moments ago`
- [ ] Repeat for the minimal validator image