### PR TITLE
Run prepare and manifest jobs on self-hosted runners

### DIFF
--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-besu.yml
+++ b/.github/workflows/build-push-besu.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-caplin.yml
+++ b/.github/workflows/build-push-caplin.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-caplin.yml
+++ b/.github/workflows/build-push-caplin.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-consensoor.yml
+++ b/.github/workflows/build-push-consensoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -85,7 +85,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-consensoor.yml
+++ b/.github/workflows/build-push-consensoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -85,7 +85,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-consensus-monitor.yml
+++ b/.github/workflows/build-push-consensus-monitor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-dummy-el.yml
+++ b/.github/workflows/build-push-dummy-el.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -79,7 +79,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-dummy-el.yml
+++ b/.github/workflows/build-push-dummy-el.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -79,7 +79,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-eleel.yml
+++ b/.github/workflows/build-push-eleel.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ere-server-zisk.yml
+++ b/.github/workflows/build-push-ere-server-zisk.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ere-server-zisk.yml
+++ b/.github/workflows/build-push-ere-server-zisk.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-erigon.yml
+++ b/.github/workflows/build-push-erigon.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-eth-das-guardian.yml
+++ b/.github/workflows/build-push-eth-das-guardian.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-eth-das-guardian.yml
+++ b/.github/workflows/build-push-eth-das-guardian.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ethereum-genesis-generator.yml
+++ b/.github/workflows/build-push-ethereum-genesis-generator.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ethereum-genesis-generator.yml
+++ b/.github/workflows/build-push-ethereum-genesis-generator.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ethereumjs.yml
+++ b/.github/workflows/build-push-ethereumjs.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ethrex.yml
+++ b/.github/workflows/build-push-ethrex.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -81,7 +81,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-ethrex.yml
+++ b/.github/workflows/build-push-ethrex.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -81,7 +81,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-execution-monitor.yml
+++ b/.github/workflows/build-push-execution-monitor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-flashbots-builder.yml
+++ b/.github/workflows/build-push-flashbots-builder.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-fuzztools.yml
+++ b/.github/workflows/build-push-fuzztools.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-fuzztools.yml
+++ b/.github/workflows/build-push-fuzztools.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -81,7 +81,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-geth.yml
+++ b/.github/workflows/build-push-geth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -81,7 +81,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-goevmlab.yml
+++ b/.github/workflows/build-push-goevmlab.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-goevmlab.yml
+++ b/.github/workflows/build-push-goevmlab.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-goomy-blob.yml
+++ b/.github/workflows/build-push-goomy-blob.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -89,7 +89,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-goteth.yml
+++ b/.github/workflows/build-push-goteth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -89,7 +89,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -133,7 +133,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -154,7 +154,7 @@ jobs:
     needs:
       - prepare
       - deploy-minimal
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-grandine.yml
+++ b/.github/workflows/build-push-grandine.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -133,7 +133,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -154,7 +154,7 @@ jobs:
     needs:
       - prepare
       - deploy-minimal
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -94,7 +94,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-lighthouse.yml
+++ b/.github/workflows/build-push-lighthouse.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -94,7 +94,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -90,7 +90,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -90,7 +90,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-meth.yml
+++ b/.github/workflows/build-push-meth.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-meth.yml
+++ b/.github/workflows/build-push-meth.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       docker_images: ${{ steps.manifest.outputs.docker_images }}
     steps:

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -106,7 +106,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-mev-boost-relay.yml
+++ b/.github/workflows/build-push-mev-boost-relay.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -106,7 +106,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -107,7 +107,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-mev-boost.yml
+++ b/.github/workflows/build-push-mev-boost.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -107,7 +107,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -93,7 +93,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-mev-rs.yml
+++ b/.github/workflows/build-push-mev-rs.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -93,7 +93,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nethermind.yml
+++ b/.github/workflows/build-push-nethermind.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nevermind.yml
+++ b/.github/workflows/build-push-nevermind.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -92,7 +92,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nevermind.yml
+++ b/.github/workflows/build-push-nevermind.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -92,7 +92,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nimbus-eth1.yml
+++ b/.github/workflows/build-push-nimbus-eth1.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -193,7 +193,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -214,7 +214,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon-minimal
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -235,7 +235,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -256,7 +256,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator-minimal
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-nimbus-eth2.yml
+++ b/.github/workflows/build-push-nimbus-eth2.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -193,7 +193,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -214,7 +214,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon-minimal
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -235,7 +235,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -256,7 +256,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator-minimal
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -201,7 +201,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -222,7 +222,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon-minimal
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -243,7 +243,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -264,7 +264,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator-minimal
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-prysm.yml
+++ b/.github/workflows/build-push-prysm.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -201,7 +201,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -222,7 +222,7 @@ jobs:
     needs:
       - prepare
       - deploy-beacon-minimal
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -243,7 +243,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest
@@ -264,7 +264,7 @@ jobs:
     needs:
       - prepare
       - deploy-validator-minimal
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ream.yml
+++ b/.github/workflows/build-push-ream.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-ream.yml
+++ b/.github/workflows/build-push-ream.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -94,7 +94,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-reth-rbuilder.yml
+++ b/.github/workflows/build-push-reth-rbuilder.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -94,7 +94,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-reth.yml
+++ b/.github/workflows/build-push-reth.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-rustic-builder.yml
+++ b/.github/workflows/build-push-rustic-builder.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-slashoor.yml
+++ b/.github/workflows/build-push-slashoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-slashoor.yml
+++ b/.github/workflows/build-push-slashoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-syncoor.yml
+++ b/.github/workflows/build-push-syncoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-syncoor.yml
+++ b/.github/workflows/build-push-syncoor.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -88,7 +88,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-tx-fuzz.yml
+++ b/.github/workflows/build-push-tx-fuzz.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -87,7 +87,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-vibehouse.yml
+++ b/.github/workflows/build-push-vibehouse.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -93,7 +93,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-vibehouse.yml
+++ b/.github/workflows/build-push-vibehouse.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -93,7 +93,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-zeam.yml
+++ b/.github/workflows/build-push-zeam.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/build-push-zeam.yml
+++ b/.github/workflows/build-push-zeam.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     outputs:
       platforms: ${{ steps.setup.outputs.platforms }}
       target_tag: ${{ steps.tag.outputs.docker_tag }}
@@ -86,7 +86,7 @@ jobs:
     needs:
       - prepare
       - deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/manifest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
   mainfest:
     name: Manifest
     needs: deploy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ghr-size-l-x64
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/manifest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
   mainfest:
     name: Manifest
     needs: deploy
-    runs-on: self-hosted-ghr-size-l-x64
+    runs-on: self-hosted-ghr-size-s-x64
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/manifest


### PR DESCRIPTION
## Summary
- Switches the `prepare` and `manifest*` jobs in every `build-push-*.yml` (and the shared `deploy.yml`) from `ubuntu-latest` to `self-hosted-ghr-size-l-x64` — the same runner already used for amd64 deploys via `runners.yaml`.
- Discord `notify` jobs are intentionally left on `ubuntu-latest`.
- 43 files, 92 lines flipped, no logic changes.

## Test plan
- [ ] Manually trigger a `build-push-*` workflow (e.g. geth) and verify both `prepare` and `manifest` schedule onto self-hosted runners and complete green.
- [ ] Confirm the scheduled job (which calls `deploy.yml`) still publishes manifests after merge.
- [ ] Confirm a deliberate failure still fires the Discord notify job (still on `ubuntu-latest`).