### PR TITLE
Re-derive git_commit_hash in manifest action to stop trailing-dash tags

### DIFF
--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -16,9 +16,9 @@ inputs:
     type: string
     required: true
   git_commit_hash:
-    description: The git commit hash that was used in the deploy action
+    description: The git commit hash that was used in the deploy action. If empty (e.g. on a manifest-only "Re-run failed jobs"), it is re-derived from source_repository@source_ref.
     type: string
-    required: true
+    required: false
   target_tag:
     description: Docker hub tag to push to
     type: string
@@ -45,6 +45,30 @@ runs:
   steps:
   - name: Checkout this repo
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  - name: Resolve git commit hash
+    id: resolve_hash
+    shell: bash
+    env:
+      INPUT_HASH: ${{ inputs.git_commit_hash }}
+      SOURCE_REPOSITORY: ${{ inputs.source_repository }}
+      SOURCE_REF: ${{ inputs.source_ref }}
+    run: |
+      hash="$INPUT_HASH"
+      if [ -z "$hash" ]; then
+        # "Re-run failed jobs" drops needs.<job>.outputs.*; re-derive so we never push a "<tag>-" trailing-dash manifest.
+        echo "git_commit_hash input was empty; re-deriving from ${SOURCE_REPOSITORY}@${SOURCE_REF}"
+        url="https://github.com/${SOURCE_REPOSITORY}.git"
+        hash=$(git ls-remote "$url" "$SOURCE_REF" 2>/dev/null | head -n1 | awk '{print $1}' | cut -c1-7)
+        if [ -z "$hash" ] && [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+          hash=$(echo "$SOURCE_REF" | cut -c1-7)
+        fi
+      fi
+      if [ -z "$hash" ]; then
+        echo "::error::Could not resolve git_commit_hash from input or by re-deriving from ${SOURCE_REPOSITORY}@${SOURCE_REF}; refusing to push trailing-dash tag"
+        exit 1
+      fi
+      echo "git_commit_hash=$hash" >> "$GITHUB_OUTPUT"
+      echo "Resolved git_commit_hash: $hash"
   - name: Generate images list
     id: generate_images_list
     shell: bash
@@ -67,11 +91,11 @@ runs:
           exists=$(echo "$response" | jq -e '.results | length > 0') || exists="false"
           if [ "$exists" == "true" ]; then
             IMAGES+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug "
-            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ inputs.git_commit_hash }} "
+            TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug ${{ inputs.target_repository }}:${{ inputs.target_tag }}-$slug-${{ steps.resolve_hash.outputs.git_commit_hash }} "
           fi
       done
 
-      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} "
+      TAGS+="${{ inputs.target_repository }}:${{ inputs.target_tag }} ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.resolve_hash.outputs.git_commit_hash }} "
 
       IMAGES=${IMAGES::-1}  # Remove the trailing space
       echo "IMAGES: $IMAGES"
@@ -111,8 +135,8 @@ runs:
   - name: Create and push manifest images to dockerhub
     shell: bash
     run: |
-      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
-      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create --dry-run -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.resolve_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
+      docker buildx imagetools create -t ${{ inputs.target_repository }}:${{ inputs.target_tag }} -t ${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.resolve_hash.outputs.git_commit_hash }} ${{ steps.generate_images_list.outputs.images }}
   - name: Create and push manifest images to harbor (best-effort)
     if: ${{ inputs.harbor_registry != '' && steps.harbor_login.outcome == 'success' }}
     continue-on-error: true
@@ -121,5 +145,5 @@ runs:
       echo "Pushing manifest to harbor registry (best-effort)..."
       docker buildx imagetools create \
         -t ${{ inputs.harbor_registry }}/${{ inputs.target_repository }}:${{ inputs.target_tag }} \
-        -t ${{ inputs.harbor_registry }}/${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ inputs.git_commit_hash }} \
+        -t ${{ inputs.harbor_registry }}/${{ inputs.target_repository }}:${{ inputs.target_tag }}-${{ steps.resolve_hash.outputs.git_commit_hash }} \
         ${{ steps.generate_images_list.outputs.images }} || echo "Harbor manifest push failed, continuing..."


### PR DESCRIPTION
## Summary

Fixes the `<tag>-` (literal trailing dash, no commit hash) pollution on Docker Hub — e.g. `ethpandaops/teku:glamsterdam-devnet-0-` pushed at 2026-04-29T13:53:54Z.

The shared manifest action concatenates `${target_tag}-${inputs.git_commit_hash}` with no validation. When the upstream `deploy` job's matrix output isn't readable — most commonly when someone uses **"Re-run failed jobs"** on the manifest job alone, since GitHub Actions [drops `needs.<job>.outputs.*` on re-runs](https://github.com/orgs/community/discussions/27905) — the input is empty and the action silently pushes a literal `<tag>-` manifest. The base `<tag>` is repointed to the same digest (so its `last_updated` doesn't move), which is exactly the fingerprint we saw on Docker Hub.

This is a structural bug in the shared action, so the fix lands once in `.github/actions/manifest/action.yml` and covers every client (`teku`, `besu`, `geth`, `lighthouse`, `lodestar`, `nethermind`, `nimbus-eth2`, `prysm`, `reth`, `grandine`, `ethrex`, …).

## Changes

- New `Resolve git commit hash` step in `manifest/action.yml`:
  - If `inputs.git_commit_hash` is non-empty → use it (current behaviour).
  - If empty → re-derive via `git ls-remote https://github.com/<source_repository>.git <source_ref>` and fall back to treating the ref as a SHA if `ls-remote` returns nothing.
  - If still empty → **fail the step** instead of pushing a trailing-dash tag.
- All 5 references to `${{ inputs.git_commit_hash }}` in the action body now read `${{ steps.resolve_hash.outputs.git_commit_hash }}`.
- `git_commit_hash` input flipped from `required: true` → `required: false` since callers no longer need to supply it for correct behaviour; description updated.

## Test plan

- [ ] Trigger a normal `build-push-teku.yml` run and confirm both `<tag>` and `<tag>-<commit>` manifests are pushed (no behaviour change on the happy path).
- [ ] Verify on a workflow that exercises Harbor (`HARBOR_REGISTRY` set) that the harbor manifest also gets the resolved commit hash.
- [ ] Force the empty-input path by triggering "Re-run failed jobs" on a manifest job whose deploy succeeded in the prior run; confirm the action re-derives the hash and pushes `<tag>-<commit>` (not `<tag>-`).
- [ ] Force a failure: pass an invalid `source_ref` with an empty `git_commit_hash`; confirm the step exits with `::error::Could not resolve git_commit_hash...` instead of pushing a trailing-dash tag.
- [ ] Manually delete the existing `ethpandaops/teku:glamsterdam-devnet-0-` tag on Docker Hub once this lands.