### PR TITLE
fix(docker-tag): force lowercase for repository and tag inputs

### DIFF
--- a/.github/actions/docker-tag/action.yml
+++ b/.github/actions/docker-tag/action.yml
@@ -24,16 +24,16 @@ runs:
       id: docker_tag
       shell: bash
       run: |
-        docker_tag="${{ inputs.input }}"
+        docker_tag="$(echo "${{ inputs.input }}" | tr '[:upper:]' '[:lower:]')"
         if [ -z "$docker_tag" ]; then
           echo "Cannot generate tag for empty input"
           exit 1
         fi
 
         # Check if repository is provided and is not the upstream repo
-        repository="${{ inputs.repository }}"
-        upstream_repo="${{ inputs.upstream_repository }}"
-        docker_tag_override="${{ inputs.docker_tag }}"
+        repository="$(echo "${{ inputs.repository }}" | tr '[:upper:]' '[:lower:]')"
+        upstream_repo="$(echo "${{ inputs.upstream_repository }}" | tr '[:upper:]' '[:lower:]')"
+        docker_tag_override="$(echo "${{ inputs.docker_tag }}" | tr '[:upper:]' '[:lower:]')"
         prefix=""
 
         # If upstream_repo is not provided, we don't add any prefix


### PR DESCRIPTION
## Summary
- The `docker-tag` composite action compared `repository` and `upstream_repository` case-sensitively, so dispatching prysm with the actual GitHub-cased `OffchainLabs/prysm` did not match the `offchainlabs/prysm` upstream and produced an `OffchainLabs-` prefix (e.g. `OffchainLabs-glamsterdam-devnet-3-minimal`).
- Lowercase all four inputs (`input`, `repository`, `upstream_repository`, `docker_tag`) before comparing and emitting the tag. Prefix detection becomes case-insensitive and tags stay fully lowercase across every workflow that uses this action.

## Test plan
- [ ] Dispatch `Build prysm docker image` with `repository=OffchainLabs/prysm` and confirm no `offchainlabs-` prefix is added to the resulting tag.
- [ ] Dispatch with a fork (e.g. `MarcoPolo/prysm`) and confirm the prefix is still applied as `marcopolo-`.
- [ ] Spot-check another client workflow (e.g. lighthouse) to confirm normal upstream dispatches are unchanged.