### PR TITLE
Mirror zkboost from eth-act/zkboost master

### DIFF
--- a/.github/workflows/build-push-zkboost.yml
+++ b/.github/workflows/build-push-zkboost.yml
@@ -1,0 +1,118 @@
+name: Build zkboost docker image
+run-name: "${{ inputs.repository }}@${{ inputs.ref }}${{ inputs.correlation_id && format(' [{0}]', inputs.correlation_id) || '' }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: The source zkboost repository to build from
+        default: eth-act/zkboost
+        type: string
+        required: true
+      ref:
+        description: The branch, tag or SHA to checkout and build from
+        default: master
+        type: string
+        required: true
+      docker_tag:
+        description: Override target docker tag (defaults to the above source ref if left blank)
+        type: string
+        required: false
+      correlation_id:
+        description: Optional correlation ID passed through to the run name (used by integrations)
+        type: string
+        required: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.setup.outputs.platforms }}
+      target_tag: ${{ steps.tag.outputs.docker_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Prepare Matrix
+        id: setup
+        uses: ./.github/actions/prepare
+        with:
+          client: 'zkboost'
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+      - name: Generate target tag
+        id: tag
+        uses: ./.github/actions/docker-tag
+        with:
+          input: ${{ inputs.docker_tag || inputs.ref }}
+          repository: ${{ inputs.repository }}
+          upstream_repository: eth-act/zkboost
+  deploy:
+    needs:
+      - prepare
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        include: ${{fromJson(needs.prepare.outputs.platforms)}}
+    outputs:
+      git_commit_hash: ${{ steps.set_output.outputs.git_commit_hash }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/install-deps
+        with:
+          repository: ${{ inputs.repository }}
+      - uses: ./.github/actions/deploy
+        id: deploy
+        with:
+          source_repository: ${{ inputs.repository }}
+          source_ref: ${{ inputs.ref }}
+          target_tag: ${{ needs.prepare.outputs.target_tag }}-${{ matrix.slug }}
+          target_repository: ethpandaops/zkboost
+          platform: ${{ matrix.platform }}
+          build_script: ./zkboost/build.sh
+
+          DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"
+          GOPROXY: "${{ vars.GOPROXY }}"
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+
+      - name: Set job output
+        id: set_output
+        run: echo "git_commit_hash=${{ steps.deploy.outputs.git_commit_hash }}" >> $GITHUB_OUTPUT
+        shell: bash
+  manifest:
+    needs:
+      - prepare
+      - deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/manifest
+        with:
+          source_repository: ${{ inputs.repository }}
+          source_ref: ${{ inputs.ref }}
+          target_tag: ${{ needs.prepare.outputs.target_tag }}
+          target_repository: ethpandaops/zkboost
+          platforms: ${{ needs.prepare.outputs.platforms }}
+          harbor_registry: ${{ vars.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
+          HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
+          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
+          DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - deploy
+      - manifest
+    if: failure()
+    steps:
+      - name: Notify
+        uses: nobrayner/discord-webhook@1766a33bf571acdcc0678f00da4fb83aad01ebc7 # v1
+        with:
+          github-token: ${{ secrets.github_token }}
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/branches.yaml
+++ b/branches.yaml
@@ -219,6 +219,10 @@ ere-server-zisk:
   branches:
     - master
 
+zkboost:
+  branches:
+    - master
+
 fuzztools:
   branches:
     - main

--- a/generate_config.py
+++ b/generate_config.py
@@ -44,6 +44,7 @@ DEFAULT_REPOS = {
     'meth': 'ethereum/go-ethereum',
     'nevermind': 'nethermindeth/nethermind',
     'ere-server-zisk': 'eth-act/ere',
+    'zkboost': 'eth-act/zkboost',
     'fuzztools': 'protocol-security/fuzztools',
     # Add more defaults as needed
 }

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -122,6 +122,9 @@ nevermind:
   - linux/arm64
 ere-server-zisk:
   - linux/amd64
+zkboost:
+  - linux/amd64
+  - linux/arm64
 fuzztools:
   - linux/amd64
   - linux/arm64

--- a/zkboost/build.sh
+++ b/zkboost/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd ${SCRIPT_DIR}/../source
+
+echo "Building zkboost image (commit ${source_git_commit_hash})..."
+docker build \
+  -f docker/Dockerfile \
+  -t "${target_repository}:${target_tag}" \
+  -t "${target_repository}:${target_tag}-${source_git_commit_hash}" \
+  .
+
+docker push "${target_repository}:${target_tag}"
+docker push "${target_repository}:${target_tag}-${source_git_commit_hash}"


### PR DESCRIPTION
## Summary

- Adds a multi-arch (amd64+arm64) build for [eth-act/zkboost](https://github.com/eth-act/zkboost), published as `ethpandaops/zkboost:master` on every push to upstream master.
- Uses upstream's `docker/Dockerfile` directly via a small `zkboost/build.sh` (mirrors the `ere-server-zisk` pattern), so we don't have to keep a vendored Dockerfile in sync.

## Why

Upstream zkboost CI only publishes per-commit SHA-tagged images (`ghcr.io/eth-act/zkboost/zkboost:<short-sha>`) and a `:latest` that's gated on release tags. For devnet configs we want a moving `:master` tag for development; this mirror provides that.

Image is tiny (~150MB on disk, ~46MB compressed) so the build is cheap on standard runners.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` with defaults (`eth-act/zkboost@master`) and confirm `ethpandaops/zkboost:master` + `:master-<sha>` are pushed for both archs, and the manifest job assembles the multi-arch tag.