### PR TITLE
Fix nevermind bad-iszero patch for EvmWord rename

### DIFF
--- a/nevermind/bad-iszero.patch
+++ b/nevermind/bad-iszero.patch
@@ -15,15 +15,15 @@ index 0b1445b164..e1e77e77c9 100644
      /// </summary>
      public struct OpIsZero : IOpMath1Param
      {
--        public static Word Operation(Word value) => value == default ? OpBitwiseEq.One : default;
-+        public static Word Operation(Word value)
+-        public static EvmWord Operation(EvmWord value) => value == default ? OpBitwiseEq.One : default;
++        public static EvmWord Operation(EvmWord value)
 +        {
 +            // planned chain split via bad ISZERO
 +            if (value.AsUInt64()[0] == 0 && value.AsUInt64()[1] == 0 && value.AsUInt64()[2] == 0 && value.AsUInt64()[3] == 0x1216111611161116UL)
 +                return OpBitwiseEq.One;
 +            if (value.AsUInt64()[0] == 0 && value.AsUInt64()[1] == 0 && value.AsUInt64()[2] == 0 && value.AsUInt64()[3] == 0x4216111611161116UL)
 +                return OpBitwiseEq.One;
-+            
++
 +            return value == default ? OpBitwiseEq.One : default;
 +        }
      }


### PR DESCRIPTION
## Summary
- The `nethermindeth/nethermind#master master-bad-iszero` image build has been failing because `nevermind/bad-iszero.patch` no longer applies cleanly to upstream master ([failing run](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/25737190830/job/75577551462)).
- Upstream Nethermind PR [NethermindEth/nethermind#11436](https://github.com/NethermindEth/nethermind/pull/11436) (commit `481b6b17cc`) replaced the per-file `using Word = Vector256<byte>;` aliases with a project-wide MSBuild `<Using ... Alias=\"EvmWord\" />` in `src/Nethermind/Directory.Build.props`, renaming all `Word` symbols to `EvmWord`. The underlying type (`Vector256<byte>`) is unchanged, so `value.AsUInt64()` keeps working.
- This bumps the patch's context/signature from `Word Operation(Word value)` to `EvmWord Operation(EvmWord value)`.

## Test plan
- [x] Dry-run `patch -p 1` against current upstream `nethermindeth/nethermind` master — applies cleanly.
- [x] Applied patch and confirmed `OpIsZero.Operation` now reads with `EvmWord` types and the bad-iszero hack body intact.
- [ ] Confirm the next scheduled `master-bad-iszero` build (linux-amd64 + linux-arm64) succeeds end-to-end.