### PR TITLE
Bump Java to 25 for teku and besu builds

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -21,7 +21,7 @@ runs:
     if: contains(inputs.repository, 'besu')
     with:
       distribution: 'temurin'
-      java-version: '21'
+      java-version: '25'
   - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
     if: contains(inputs.repository, 'lodestar') || contains(inputs.repository, 'ethereumjs')
     with:

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -16,7 +16,7 @@ runs:
     if: contains(inputs.repository, 'teku')
     with:
       distribution: 'temurin'
-      java-version: '21'
+      java-version: '25'
   - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
     if: contains(inputs.repository, 'besu')
     with:


### PR DESCRIPTION
## Summary

- Teku master upgraded `targetJavaVersion` to Java 25 ([consensys/teku#10567](https://github.com/Consensys/teku/pull/10567)), causing the scheduled teku build to fail with the JDK 21 currently installed by `install-deps`.
- Bumps both teku and besu to JDK 25. Besu still pins `sourceCompatibility = 21` but builds fine on a newer JDK.

Fixes the failure in [run 25982909839](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/25982909839/job/76374906806).

## Test plan

- [x] Trigger a teku master build on this branch and confirm it succeeds. — [run 26029821633](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/26029821633) ✅ (amd64 + arm64 + manifest, tag `jdk25-test-147ba3`)
- [x] Trigger a besu main build on this branch and confirm it succeeds. — [run 26029819949](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/26029819949) ✅ (amd64 + arm64 + manifest, tag `jdk25-test-147ba3`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUP3ZovsgpDL8DyNKQ4s3J)_