### PR TITLE
Add branch:tag override syntax in branches.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ Add a new image to [`config.yaml`](./config.yaml) file and it will be built on s
     dockerfile: ./lighthouse/Dockerfile # optional docker file to use, defaults to the source repository's Dockerfile
 ```
 
+## `branches.yaml` syntax
+
+`config.yaml` is generated from `branches.yaml` by `generate_config.py`. Each client lists branches that should be built; the branch name is used directly as the docker tag (slashes become hyphens).
+
+To build from one branch but publish under a different tag, use `<branch>:<tag>`:
+
+```yaml
+teku:
+  branches:
+    - master
+    - prototype/focil:focil   # builds prototype/focil, publishes as :focil
+```
+
+The same syntax works inside `alt_repos` entries (the alt-repo prefix is still prepended to the override tag).
+
+After editing `branches.yaml`, run `python3 generate_config.py` to regenerate `config.yaml`.
+
 ## Per-tag Dockerfile convention
 
 When a build needs a different Dockerfile than the default (e.g. an alt-fork branch that doesn't work with the upstream one), drop it in alongside the default using the naming convention:

--- a/branches.yaml
+++ b/branches.yaml
@@ -2,6 +2,10 @@
 
 # Default upstream repository is assumed for each client
 # Branch names are used directly as tags unless in alt_repos
+#
+# Tag override: use "<branch>:<tag>" to build from <branch> but publish as <tag>.
+# Example: "prototype/focil:focil" builds the prototype/focil branch and tags it "focil".
+# Without an override, slashes in branch names are replaced with hyphens for the tag.
 
 besu:
   branches:
@@ -122,7 +126,7 @@ teku:
     - optional-proofs
     - glamsterdam-devnet-0
     - glamsterdam-devnet-2
-    - focil
+    - prototype/focil:focil
 
 eleel:
   branches:

--- a/generate_config.py
+++ b/generate_config.py
@@ -113,9 +113,9 @@ def generate_config():
         # Process main branches
         if 'branches' in client_config:
             for branch_spec in client_config['branches']:
-                # Check if this is a branch with special tag
-                if '@' in branch_spec:
-                    branch, special_tag = branch_spec.split('@', 1)
+                # Check if this is a branch with a tag override (e.g. "prototype/focil:focil")
+                if ':' in branch_spec:
+                    branch, special_tag = branch_spec.split(':', 1)
                     process_branch(client_name, default_repo, branch, special_tag, config_list)
                 else:
                     # Regular branch
@@ -153,9 +153,9 @@ def generate_config():
                 prefix = repo_parts[0].lower()
 
                 for branch_spec in branches:
-                    # Check if this is a branch with special tag
-                    if '@' in branch_spec:
-                        branch, special_tag = branch_spec.split('@', 1)
+                    # Check if this is a branch with a tag override (e.g. "prototype/focil:focil")
+                    if ':' in branch_spec:
+                        branch, special_tag = branch_spec.split(':', 1)
                         # Create the target tag with prefix and special tag
                         target_tag = f"{prefix}-{special_tag}"
                         process_branch(client_name, alt_repo, branch, target_tag, config_list)


### PR DESCRIPTION
## Summary
- `branches.yaml` now accepts `<branch>:<tag>` entries — build from `<branch>` but publish under `<tag>`. Replaces the previously unused `@` separator (which read as a git commit specifier and was a footgun), freeing `@` for future commit-pinning.
- Applied to teku focil: `prototype/focil:focil` so it tracks the actual upstream branch instead of the nonexistent `focil` (which is why scheduled focil builds were failing).
- README + branches.yaml header updated to document the syntax.

## Test plan
- [x] `python3 generate_config.py` runs cleanly — generates `target.tag: focil` with `source.ref: prototype/focil` for teku focil.
- [ ] Trigger scheduled or manual teku focil build after merge and confirm it pulls `prototype/focil` and publishes `ethpandaops/teku:focil`.