### PR TITLE
Skip missing upstream branches in scheduled build

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -166,6 +166,11 @@ jobs:
           while IFS=$'\t' read -r LINE SOURCE_REPOSITORY SOURCE_REF TARGET_REPOSITORY TARGET_TAG; do
               # get the image commit hash from LINE
               COMMIT_HASH=$(echo "$COMMITS" | jq -r --arg LINE "$LINE" '.[] | select(.line == $LINE) | .commit_hash')
+              # Skip configs whose upstream ref couldn't be resolved (process_commits already logged the cause);
+              # otherwise we'd query Docker Hub for a malformed "<tag>-" image and queue a build that has no source.
+              if [[ -z "$COMMIT_HASH" || "$COMMIT_HASH" == "null" ]]; then
+                  continue
+              fi
               IMAGE_TAG="${TARGET_TAG}-${COMMIT_HASH}"
               IMAGE="${TARGET_REPOSITORY}:${IMAGE_TAG}"
               URL="https://hub.docker.com/v2/repositories/${TARGET_REPOSITORY}/tags?page_size=25&page=1&ordering=&name=${IMAGE_TAG}"
@@ -195,12 +200,30 @@ jobs:
           done
 
           CONFIGS="configs=["
+          SKIPPED_HEADER_WRITTEN=0
 
           echo "Generating configuration files..."
           while IFS=$'\t' read -r LINE SOURCE_REPOSITORY SOURCE_REF SOURCE_PATCH TARGET_REPOSITORY TARGET_TAG; do
               # get the image commit hash from LINE
               COMMIT_HASH=$(echo "$COMMITS" | jq -r --arg LINE "$LINE" '.[] | select(.line == $LINE) | .commit_hash')
               COMMIT_HASH_FULL=$(echo "$COMMITS" | jq -r --arg LINE "$LINE" '.[] | select(.line == $LINE) | .commit_hash_full')
+              # Missing upstream ref: emit a workflow warning + run-summary entry instead of letting
+              # the deploy step fail on `actions/checkout`. Self-healing — once the branch lands upstream,
+              # process_commits gets a SHA and the next run builds it normally.
+              if [[ -z "$COMMIT_HASH" || "$COMMIT_HASH" == "null" ]]; then
+                  echo "::warning::Skipping ${SOURCE_REPOSITORY}#${SOURCE_REF} -> ${TARGET_REPOSITORY}:${TARGET_TAG}: upstream ref not found"
+                  if [ "$SKIPPED_HEADER_WRITTEN" = "0" ]; then
+                      {
+                          echo "## Skipped builds (upstream ref missing)"
+                          echo ""
+                          echo "| Source | Target |"
+                          echo "| --- | --- |"
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      SKIPPED_HEADER_WRITTEN=1
+                  fi
+                  echo "| \`${SOURCE_REPOSITORY}#${SOURCE_REF}\` | \`${TARGET_REPOSITORY}:${TARGET_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
+                  continue
+              fi
               IMAGE_TAG="${TARGET_TAG}-${COMMIT_HASH}"
               IMAGE="${TARGET_REPOSITORY}:${IMAGE_TAG}"
               CLIENT="${TARGET_REPOSITORY#*/}"


### PR DESCRIPTION
## Summary

The hourly **Scheduled** workflow has been failing on every run because `branches.yaml` lists branches that don't (yet) exist on the upstream repo — most recently `geth/bal-devnet-7`. Each failure also pings Discord, so the signal-to-noise on real breakages is poor.

### Root cause

`process_commits` in `.github/workflows/scheduled.yml` already detects a missing upstream ref via the GitHub API and logs:

```
[LINE:28] Error fetching commit hash for ethereum/go-ethereum#bal-devnet-7, skipping.
```

…but the downstream loops still iterate over **every** config in `config.yaml`. For the missing entry:

1. `COMMIT_HASH` comes back empty.
2. The Docker Hub check queries the malformed image `ethpandaops/geth:bal-devnet-7-` (trailing dash).
3. That tag (unsurprisingly) doesn't exist, so the entry is classified as "needs build" and added to the deploy matrix.
4. The deploy job fails at `actions/checkout` with `A branch or tag with the name 'bal-devnet-7' could not be found`.

Confirmed against the latest run (`gh run 26026938948`).

### Fix

Two narrow changes inside the `check` job:

- **Docker Hub existence loop** — `continue` when `COMMIT_HASH` is empty/null. Avoids wasted Docker Hub queries against malformed tags.
- **Build-config generation loop** — same skip, plus a `::warning::` annotation and a row appended to `$GITHUB_STEP_SUMMARY` (under a `## Skipped builds (upstream ref missing)` heading written once).

The workflow stays green, the Discord notification step (`if: cancelled() || failure()`) no longer fires for missing-branch noise, and every skipped branch is plainly visible on the run page.

### Self-healing

No state is persisted. The moment the branch is pushed upstream, the GitHub API returns a SHA on the next hourly cron → `COMMIT_HASH` is non-empty → the skip branch isn't taken → Docker Hub reports the proper `<tag>-<sha>` image missing → the build runs and pushes normally. No manual intervention needed when the branch reappears.

## Test plan

- [ ] Trigger `gh workflow run scheduled.yml` after merge.
- [ ] Confirm the run is green even though `geth/bal-devnet-7` is still missing upstream.
- [ ] Confirm a `::warning::` annotation appears on the run page for the missing entry.
- [ ] Confirm the run summary contains a `Skipped builds (upstream ref missing)` table listing the geth row (and any others).
- [ ] Confirm an existing branch (e.g. `geth/master`) still builds normally if its image is missing on Docker Hub.
- [ ] Confirm no Discord notification fires for the skipped entries.