### PR TITLE
feat: pass GIT_SHA/GIT_BRANCH/VERSION build args to docker build

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -210,6 +210,9 @@ runs:
       build-args: |
         ${{ inputs.build_args }}
         COMMIT_HASH=${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
+        GIT_SHA=${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
+        GIT_BRANCH=${{ inputs.source_ref }}
+        VERSION=${{ inputs.source_ref }}
       labels: |
         ethpandaops.io.repo=${{ inputs.source_repository }}
         ethpandaops.io.commitRef=${{ inputs.source_ref }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -212,7 +212,7 @@ runs:
         COMMIT_HASH=${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
         GIT_SHA=${{ steps.git_commit_hash_full.outputs.git_commit_hash_full }}
         GIT_BRANCH=${{ inputs.source_ref }}
-        VERSION=${{ inputs.source_ref }}
+        VERSION=${{ inputs.source_ref }}-${{ steps.git_commit_hash.outputs.git_commit_hash }}
       labels: |
         ethpandaops.io.repo=${{ inputs.source_repository }}
         ethpandaops.io.commitRef=${{ inputs.source_ref }}


### PR DESCRIPTION
Forwards `GIT_SHA`, `GIT_BRANCH` and `VERSION` to the docker build in the deploy action. `GIT_SHA` is the full commit that's already computed for `COMMIT_HASH`, `GIT_BRANCH` is the source ref, and `VERSION` is the source ref plus the short commit (e.g. `main-626c2f2`).

We changed the ethrex Dockerfile and it now reads these build args to stamp the version into the image. Without them the ethpandaops/ethrex images report an unknown version/commit and the OCI revision/version labels come out empty.

The values are already on hand here, so this just passes them through. Clients that don't declare the matching ARGs ignore them (BuildKit drops unused build args), same as COMMIT_HASH today.