### PR TITLE
fix: retry Docker Buildx setup on transient registry failures

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -131,6 +131,17 @@ runs:
     run: |
       docker context use builders || docker context create builders
   - name: Set up Docker Buildx
+    id: buildx_setup
+    continue-on-error: true
+    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    with:
+      endpoint: builders
+  - name: Wait before retrying Docker Buildx setup
+    if: steps.buildx_setup.outcome == 'failure'
+    shell: bash
+    run: sleep 30
+  - name: Set up Docker Buildx (retry)
+    if: steps.buildx_setup.outcome == 'failure'
     uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
     with:
       endpoint: builders

--- a/.github/actions/manifest/action.yml
+++ b/.github/actions/manifest/action.yml
@@ -114,6 +114,17 @@ runs:
     run: |
       docker context create builders
   - name: Set up Docker Buildx
+    id: buildx_setup
+    continue-on-error: true
+    uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    with:
+      endpoint: builders
+  - name: Wait before retrying Docker Buildx setup
+    if: steps.buildx_setup.outcome == 'failure'
+    shell: bash
+    run: sleep 30
+  - name: Set up Docker Buildx (retry)
+    if: steps.buildx_setup.outcome == 'failure'
     uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
     with:
       endpoint: builders

--- a/.github/workflows/build-push-beacon-metrics-gazer.yml
+++ b/.github/workflows/build-push-beacon-metrics-gazer.yml
@@ -72,7 +72,6 @@ jobs:
           harbor_registry: ${{ vars.HARBOR_REGISTRY }}
           HARBOR_USERNAME: "${{ vars.HARBOR_USERNAME }}"
           HARBOR_PASSWORD: "${{ secrets.HARBOR_PASSWORD }}"
-          git_commit_hash: ${{ needs.deploy.outputs.git_commit_hash }}
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           MACOS_PASSWORD: "${{ secrets.MACOS_PASSWORD }}"

--- a/.github/workflows/build-push-lodestar.yml
+++ b/.github/workflows/build-push-lodestar.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           source_repository: ${{ inputs.repository }}
           source_ref: ${{ inputs.ref }}
-          build_script: ./lodestar/build.sh
           target_tag: ${{ needs.prepare.outputs.target_tag }}
           target_repository: ethpandaops/lodestar
           platforms: ${{ needs.prepare.outputs.platforms }}


### PR DESCRIPTION
## Problem

The `manifest` job in [this lodestar run](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/27282789182/job/80583090611) failed because booting the buildkit container timed out pulling `moby/buildkit:buildx-stable-1` from Docker Hub:

```
ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

A single transient registry hiccup kills the whole job today.

## Fix

In both the `deploy` and `manifest` composite actions, the `docker/setup-buildx-action` step now runs with `continue-on-error: true`, and if it fails we wait 30s and run it a second time. The retry step fails the job for real if the second attempt also fails. `setup-buildx-action` generates a unique builder name per invocation, so the retry doesn't collide with the failed first attempt.

## Bonus cleanup

Removed the stray `build_script` input passed to the manifest action in `build-push-lodestar.yml` — the manifest action doesn't define that input, so it only produced an `Unexpected input(s)` warning (visible in the same log).