### PR TITLE
prysm: enable progressive merkleization on branches that gate it off

### DIFF
--- a/prysm/build_beacon.sh
+++ b/prysm/build_beacon.sh
@@ -38,15 +38,22 @@ END
     ;;
   "bazel")
     echo "Building with Bazel..."
+    # Branches carrying the //tools:disable_progressive_merkleization build setting
+    # (glamsterdam-devnet-7+) gate progressive SSZ merkleization off in their
+    # .bazelrc for spectest compatibility; devnet images need it enabled.
+    extra_bazel_flags=""
+    if grep -qs "disable_progressive_merkleization" tools/BUILD.bazel; then
+      extra_bazel_flags="--//tools:disable_progressive_merkleization=false"
+    fi
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags} --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}
       fi
     fi
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain

--- a/prysm/build_beacon_minimal.sh
+++ b/prysm/build_beacon_minimal.sh
@@ -38,15 +38,22 @@ END
     ;;
   "bazel")
     echo "Building with Bazel..."
+    # Branches carrying the //tools:disable_progressive_merkleization build setting
+    # (glamsterdam-devnet-7+) gate progressive SSZ merkleization off in their
+    # .bazelrc for spectest compatibility; devnet images need it enabled.
+    extra_bazel_flags=""
+    if grep -qs "disable_progressive_merkleization" tools/BUILD.bazel; then
+      extra_bazel_flags="--//tools:disable_progressive_merkleization=false"
+    fi
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags} --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/beacon-chain:beacon-chain --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}
       fi
     fi
     mv bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain _beacon-chain

--- a/prysm/build_validator.sh
+++ b/prysm/build_validator.sh
@@ -38,15 +38,22 @@ END
     ;;
   "bazel")
     echo "Building with Bazel..."
+    # Branches carrying the //tools:disable_progressive_merkleization build setting
+    # (glamsterdam-devnet-7+) gate progressive SSZ merkleization off in their
+    # .bazelrc for spectest compatibility; devnet images need it enabled.
+    extra_bazel_flags=""
+    if grep -qs "disable_progressive_merkleization" tools/BUILD.bazel; then
+      extra_bazel_flags="--//tools:disable_progressive_merkleization=false"
+    fi
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags} --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=release --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}
       fi
     fi
     mv bazel-bin/cmd/validator/validator_/validator _validator

--- a/prysm/build_validator_minimal.sh
+++ b/prysm/build_validator_minimal.sh
@@ -38,15 +38,22 @@ END
     ;;
   "bazel")
     echo "Building with Bazel..."
+    # Branches carrying the //tools:disable_progressive_merkleization build setting
+    # (glamsterdam-devnet-7+) gate progressive SSZ merkleization off in their
+    # .bazelrc for spectest compatibility; devnet images need it enabled.
+    extra_bazel_flags=""
+    if grep -qs "disable_progressive_merkleization" tools/BUILD.bazel; then
+      extra_bazel_flags="--//tools:disable_progressive_merkleization=false"
+    fi
     # Try with remote cache first
-    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
+    if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags} --remote_cache=grpcs://bazel-remote-cache-grpc.primary.production.platform.ethpandaops.io:443; then
       echo "Build failed with remote cache, trying without remote cache..."
       # Try without remote cache to avoid cache corruption issues
-      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false; then
+      if ! $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}; then
         echo "Build still failing, cleaning local Bazel cache and retrying..."
         # Clean the local Bazel cache and try once more
         $HOME/go/bin/bazelisk clean --expunge
-        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false
+        $HOME/go/bin/bazelisk build //cmd/validator:validator --config=minimal --stamp --define pgo_enabled=0 --enable_bzlmod=false ${extra_bazel_flags}
       fi
     fi
     mv bazel-bin/cmd/validator/validator_/validator _validator


### PR DESCRIPTION
## Why

`glamsterdam-devnet-7` introduces a `//tools:disable_progressive_merkleization` build setting and forces it on in its `.bazelrc` (spectest fixture compatibility). Without an override our devnet-7 images build with progressive SSZ merkleization dormant → wrong hash tree roots for the devnet. The prysm team asked us to pass `--//tools:disable_progressive_merkleization=false`.

## What

All four prysm build scripts (beacon/validator × mainnet/minimal) now append `--//tools:disable_progressive_merkleization=false` to every bazelisk invocation **iff** the source tree defines the setting (grep of `tools/BUILD.bazel`):

- Branches without the setting (`develop`, `master`, forks, old commits) run a byte-identical command to before — passing the flag there would fail with "no such target".
- Any future branch carrying the setting (including an eventual merge to master) picks it up automatically, no per-branch config.

## Testing

- Full local run of `build_beacon.sh` and `build_validator.sh` against a fresh `glamsterdam-devnet-7` clone: bazel build (remote cache hit), docker build, push, container runs and reports the branch head commit.
- `bazel aquery` on `ssz_methodical` codegen: `--disable-progressive` present without the override, absent with it — the flag provably takes effect.
- Negative check on `develop`: conditional adds nothing.

Note: first CI build after merge is slower for devnet-7 (new remote-cache keys from the changed build setting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)