### PR TITLE
erigon: add binary-trie branch

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -28,6 +28,7 @@ el:
       branches:
         - main
         - performance
+        - binary-trie
     ethrex:
       branches:
         - main


### PR DESCRIPTION
Erigon's EIP-8297 partitioned binary tree branch, for ethpandaops/eth-client-docker-image-builder#398.

Implementation: erigontech/erigon#22942