### PR TITLE
Build a Nethermind frames image

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -50,6 +50,7 @@ el:
         - master
         - performance
         - eip-7904
+        - eip8141-frame-txs-devnet7:frames
     nimbus-eth1:
       branches:
         - master


### PR DESCRIPTION
Adds the Nethermind EIP-8141 frame transactions branch so there is a stable image to point a frames devnet at.

The branch is `eip8141-frame-txs-devnet7` and it sits on top of glamsterdam-devnet-7. I used the tag override so the published tag is `frames` rather than the devnet number, because the branch will move to later baselines while the tag should stay the same.

`config.yaml` regenerates cleanly with `python3 generate_config.py`, producing `ethpandaops/nethermind:frames`.

Draft because the tag name is really a question for you. `frames` matches what came up in the devnet thread alongside `focil`, but I am happy to publish it under a different name.
