### PR TITLE
prysm: build decoupled-casper branch

### DIFF
--- a/branches.yaml
+++ b/branches.yaml
@@ -108,6 +108,8 @@ cl:
           - buildoor-apis
         syjn99/prysm:
           - prototype/ssz-over-http
+        sukunrt/prysm:
+          - decoupled-casper
     teku:
       branches:
         - master


### PR DESCRIPTION
Add `sukunrt/prysm@decoupled-casper` to the scheduled Prysm builds.

This generates the standard beacon-chain and validator images, including their minimal variants:

- `ethpandaops/prysm-beacon-chain:sukunrt-decoupled-casper`
- `ethpandaops/prysm-beacon-chain:sukunrt-decoupled-casper-minimal`
- `ethpandaops/prysm-validator:sukunrt-decoupled-casper`
- `ethpandaops/prysm-validator:sukunrt-decoupled-casper-minimal`

Validation:
- `uv run --with pyyaml python3 generate_config.py`
- `uvx --from yamale yamale -s schema.yaml config.yaml`
- duplicate repository/tag check returned `[]`