### PR TITLE
Fix lighthouse, grandine and teku trunk builds

### DIFF
--- a/.github/workflows/build-push-teku.yml
+++ b/.github/workflows/build-push-teku.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       repository:
         description: The source teku repository to build from
-        default: consensys/teku
+        default: consensys-incorporated/teku
         type: string
         required: true
       ref:
@@ -44,7 +44,7 @@ jobs:
         with:
           input: ${{ inputs.docker_tag || inputs.ref }}
           repository: ${{ inputs.repository }}
-          upstream_repository: consensys/teku
+          upstream_repository: consensys-incorporated/teku
           docker_tag: ${{ inputs.docker_tag }}
   deploy:
     needs:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run the *Build **client*** workflow;
 - [Build Nimbus-Eth1](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-nimbus-eth1.yml) [[source](https://github.com/status-im/nimbus-eth1)]
 - [Build Prysm](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-prysm.yml) [[source](https://github.com/offchainlabs/prysm)]
 - [Build Reth](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-reth.yml) [[source](https://github.com/paradigmxyz/reth)]
-- [Build Teku](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-teku.yml) [[source](https://github.com/consensys/teku)]
+- [Build Teku](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-teku.yml) [[source](https://github.com/consensys-incorporated/teku)]
 - [Build Grandine](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-grandine.yml) [[source](https://github.com/grandinetech/grandine)]
 - [Build Zeam](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-zeam.yml) [[source](https://github.com/blockblaz/zeam)]
 - [Build Ream](https://github.com/ethpandaops/eth-client-docker-image-builder/actions/workflows/build-push-ream.yml) [[source](https://github.com/ReamLabs/ream)]

--- a/generate_config.py
+++ b/generate_config.py
@@ -18,7 +18,7 @@ DEFAULT_REPOS = {
     'nimbus-eth1': 'status-im/nimbus-eth1',
     'prysm-beacon-chain': 'offchainlabs/prysm',
     'prysm-validator': 'offchainlabs/prysm',
-    'teku': 'consensys/teku',
+    'teku': 'consensys-incorporated/teku',
     'lodestar': 'chainsafe/lodestar',
     'reth': 'paradigmxyz/reth',
     'nethermind': 'nethermindeth/nethermind',

--- a/grandine/Dockerfile
+++ b/grandine/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82.0-bullseye AS builder
+FROM rust:1.82.0-bookworm AS builder
 RUN apt-get clean && apt-get update && apt-get --yes upgrade && apt-get install --yes cmake libclang-dev
 COPY . .
 RUN scripts/build/release.sh

--- a/grandine/Dockerfile.minimal
+++ b/grandine/Dockerfile.minimal
@@ -1,4 +1,4 @@
-FROM rust:1.82.0-bullseye AS builder
+FROM rust:1.82.0-bookworm AS builder
 RUN apt-get clean && apt-get update && apt-get --yes upgrade && apt-get install --yes cmake libclang-dev
 COPY . .
 RUN scripts/build/minimal.sh

--- a/lighthouse/Dockerfile
+++ b/lighthouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88-bullseye AS builder
+FROM rust:1.88-bookworm AS builder
 RUN apt-get clean && apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG FEATURES=gnosis,spec-minimal,slasher-lmdb

--- a/lighthouse/Dockerfile
+++ b/lighthouse/Dockerfile
@@ -9,7 +9,7 @@ ENV PROFILE=$PROFILE
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd lighthouse && make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get clean && apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/lighthouse/Dockerfile.eth-act-optional-proofs
+++ b/lighthouse/Dockerfile.eth-act-optional-proofs
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-bullseye AS builder
+FROM rust:1.88.0-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends cmake libclang-dev clang \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/lighthouse/target \
     make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \


### PR DESCRIPTION
The scheduled workflow has failed on every run since 2026-09-02, so `lighthouse:unstable` (last 09-04), `grandine:develop` (09-03) and `teku:master` (09-01) are stale while glamsterdam-devnet-11 is supposed to launch on trunk images.

- **lighthouse, grandine**: both Dockerfiles build `FROM rust:*-bullseye`; the bullseye-security `InRelease` file is expired, so `apt-get update` exits 100 (`E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired`, e.g. run 34189814695). Moved to the bookworm variants of the same rust versions; lighthouse upstream already builds on `rust:1.88.0-bookworm`. Both `apt-get` layers verified locally on the new bases.
- **teku**: the repo moved to `Consensys-Incorporated/teku` on 2026-08-20. `consensys/teku` now 301-redirects and the non-following `curl` in `scheduled.yml` reports `upstream ref not found`, so the build is skipped. Updated `generate_config.py`, the teku workflow default and the README link (`consensys-incorporated/teku`, verified the API accepts the lowercase form).

Not touched: `erigon#main` also fails, but only the caplin job (`make caplin` exit 2); the erigon EL image still publishes.

https://claude.ai/code/session_01RvpCA61tEGuuzmYFQuWvHG